### PR TITLE
add a --version option, set defaults fix error in glob

### DIFF
--- a/src/cmip7_prep/__init__.py
+++ b/src/cmip7_prep/__init__.py
@@ -1,3 +1,22 @@
 """CMIP7 preparation toolkit: regridding and CMOR writing for CESM outputs."""
 
+import subprocess
+
+
+def _get_git_version():
+    try:
+        version = (
+            subprocess.check_output(
+                ["git", "describe", "--tags", "--abbrev=0"], stderr=subprocess.STDOUT
+            )
+            .decode("utf-8")
+            .strip()
+        )
+        return version
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+__version__ = _get_git_version()
+
 __all__ = ["regrid", "cmor_writer"]


### PR DESCRIPTION
Current main has a recursion issue when a full directory of input is applied, we do not need glob in pipeline.py since it is in cmor_driver.py.

Add a --version option and tie it to the github tag.  