### PR TITLE
add positive dictionary to noresm 

### DIFF
--- a/data/noresm_to_cmip7.yaml
+++ b/data/noresm_to_cmip7.yaml
@@ -1755,6 +1755,7 @@ variables:
   ta_tavg-p39-hy-air:
     description: Air Temperature
     dims: [time, plev, lat]
+    formula: zonal_mean_on_pressure_grid("T")
     levels: {name: plev39, units: Pa}
     sources: [model_var: T]
     table: atmos
@@ -1955,6 +1956,7 @@ variables:
   ua_tavg-p39-hy-air:
     description: Zonal wind (positive in a eastward direction).
     dims: [time, plev, lat]
+    formula: zonal_mean_on_pressure_grid("U")
     levels: {name: plev39, units: Pa}
     sources: [model_var: U]
     table: atmos
@@ -1980,6 +1982,7 @@ variables:
   va_tavg-p39-hy-air:
     description: Meridional wind (positive in a northward direction).
     dims: [time, plev, lat]
+    formula: zonal_mean_on_pressure_grid("V")
     levels: {name: plev39, units: Pa}
     sources: [model_var: V]
     table: atmos
@@ -2125,6 +2128,7 @@ variables:
       It is numerically similar to the altitude (or geometric height) and not to the
       quantity with standard name height, which is relative to the surface.
     dims: [time, plev, lat]
+    formula: zonal_mean_on_pressure_grid("Z3")
     levels: {name: plev39, units: Pa}
     sources: [model_var: Z3]
     table: atmos

--- a/data/noresm_to_cmip7.yaml
+++ b/data/noresm_to_cmip7.yaml
@@ -17,7 +17,6 @@ variables:
     description: This is the monthly averaged aerosol optical thickness at 550 nm
       due to stratospheric volcanic sulphate aerosols
     dims: [lon, lat, time, lambda550nm]
-    long_name: Amon.aod550volso4
     sources: [model_var: AODVVOLC]
     table: atmos
     units: '1.00E-09'
@@ -28,7 +27,6 @@ variables:
       areas should be defined to enable exact calculation of global integrals (e.g.,
       of vertical fluxes of energy at the surface and top of the atmosphere).
     dims: [lon, lat]
-    long_name: fx.areacella
     sources: [model_var: area]
     table: atmos
     units: m2
@@ -43,7 +41,6 @@ variables:
   bldep_tavg-u-hxy-u:
     description: Boundary layer depth
     dims: [lon, lat, time]
-    long_name: AERmon.bldep
     sources: [model_var: PBLH]
     table: atmos
     units: m
@@ -53,7 +50,6 @@ variables:
       and anthropogenic fires and those associated with anthropogenic land use change
     dims: [lon, lat, time, typeburnt]
     formula: (FATES_BURNFRAC *3600*24*30*100)*FATES_FRACTION
-    long_name: Lmon.burntFractionAll
     sources: [model_var: FATES_BURNFRAC, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -63,7 +59,6 @@ variables:
       grass, crops, and trees).
     dims: [lon, lat, time, typec3pft]
     formula: (FATES_AREA_PLANTS-sumoverpft(FATES_CROWNAREA_PF, pftlist=[14], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Lmon.c3PftFrac
     sources: [model_var: FATES_AREA_PLANTS, model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -73,7 +68,6 @@ variables:
       grass and crops).
     dims: [lon, lat, time, typec4pft]
     formula: sumoverpft(FATES_CROWNAREA_PF, pftlist=[14], dim='fates_levpft')*FATES_FRACTION
-    long_name: Lmon.c4PftFrac
     sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -82,7 +76,6 @@ variables:
     description: Report missing data over ocean grid cells. For fractional land report
       value averaged over the land fraction.
     dims: [lon, lat, time]
-    long_name: Emon.cLand
     sources: [model_var: TOTECOSYSC]
     table: land
     units: kg m-2
@@ -90,7 +83,6 @@ variables:
   cLeaf_tavg-u-hxy-lnd:
     description: Carbon mass per unit area in leaves.
     dims: [lon, lat, time]
-    long_name: Lmon.cLeaf
     sources: [model_var: FATES_LEAFC]
     table: land
     units: kg m-2
@@ -100,7 +92,6 @@ variables:
       dead organic matter composed of coarse wood. It is distinct from fine litter.
       The precise distinction between "fine" and "coarse" is model dependent.'
     dims: [lon, lat, time]
-    long_name: Emon.cLitterCwd
     sources: [model_var: FATES_LITTER_BG_CWD_EL]
     table: land
     units: kg m-2
@@ -109,7 +100,6 @@ variables:
     description: subsurface litter pool fed by root inputs.
     dims: [lon, lat, time]
     formula: (FATES_LITTER_BG_FINE_EL + FATES_LITTER_BG_CWD_EL)*FATES_FRACTION
-    long_name: Emon.cLitterSubSurf
     sources: [model_var: FATES_LITTER_BG_FINE_EL, model_var: FATES_LITTER_BG_CWD_EL,
       model_var: FATES_FRACTION]
     table: land
@@ -119,7 +109,6 @@ variables:
     description: Surface or near-surface litter pool fed by leaf and above-ground
       litterfall
     dims: [lon, lat, time]
-    long_name: Emon.cLitterSurf
     sources: [model_var: FATES_LITTER_AG_FINE_EL]
     table: land
     units: kg m-2
@@ -127,7 +116,6 @@ variables:
   cOther_tavg-u-hxy-lnd:
     description: E.g. fruits, seeds, etc.
     dims: [lon, lat, time]
-    long_name: Emon.cOther
     sources: [model_var: FATES_SEED_BANK]
     table: land
     units: kg m-2
@@ -137,7 +125,6 @@ variables:
       through  land use change.
     dims: [lon, lat, time]
     formula: CROPPROD1C+TOT_WOODPRODC
-    long_name: Lmon.cProduct
     sources: [model_var: CROPPROD1C, model_var: TOT_WOODPRODC]
     table: land
     units: kg m-2
@@ -146,7 +133,6 @@ variables:
     description: For models with multiple soil carbon pools, report each pool here.
       If models also have vertical discretisation these should be aggregated
     dims: [lon, lat, soilpools, time]
-    long_name: Emon.cSoilPools
     sources: [model_var: SOIL1C, model_var: SOIL2C, model_var: SOIL3C, model_var: SOIL4C]
     table: land
     units: kg m-2
@@ -155,7 +141,6 @@ variables:
     description: Report missing data over ocean grid cells. For fractional land report
       value averaged over the land fraction.
     dims: [lon, lat, time, sdepth100cm]
-    long_name: Emon.cSoilAbove1m
     sources: [model_var: TOTSOMC_1m]
     table: land
     units: kg m-2
@@ -165,7 +150,6 @@ variables:
       soil carbon for each level
     dims: [lon, lat, sdepth, time]
     formula: SOIL1C_vr+SOIL2C_vr+SOIL3C_vr+SOIL4C_vr
-    long_name: Emon.cSoilLevels
     sources: [model_var: SOIL1C_vr, model_var: SOIL2C_vr, model_var: SOIL3C_vr,
       model_var: SOIL4C_vr]
     table: land
@@ -174,7 +158,6 @@ variables:
   cSoil_tavg-u-hxy-lnd:
     description: Carbon mass in the full depth of the soil model.
     dims: [lon, lat, time]
-    long_name: Emon.cSoil
     sources: [model_var: TOTSOMC]
     table: land
     units: kg m-2
@@ -182,7 +165,6 @@ variables:
   cStem_tavg-u-hxy-lnd:
     description: including sapwood and hardwood.
     dims: [lon, lat, time]
-    long_name: Emon.cStem
     sources: [model_var: FATES_STRUCTC]
     table: land
     units: kg m-2
@@ -191,7 +173,6 @@ variables:
     description: Carbon mass per unit area in vegetation.
     dims: [lon, lat, time]
     formula: FATES_VEGC *FATES_FRACTION
-    long_name: Lmon.cVeg
     sources: [model_var: FATES_VEGC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
@@ -202,7 +183,6 @@ variables:
       of biomass using carbon obtained from carbon dioxide.'
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_VEGC_PF, pftlist=[12, 13, 14], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.cVegGrass
     sources: [model_var: FATES_VEGC_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
@@ -213,7 +193,6 @@ variables:
       of biomass using carbon obtained from carbon dioxide.'
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_VEGC_PF, pftlist=[7, 8, 9, 10, 11], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.cVegShrub
     sources: [model_var: FATES_VEGC_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
@@ -224,7 +203,6 @@ variables:
       of biomass using carbon obtained from carbon dioxide.'
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_VEGC_PF, pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.cVegTree
     sources: [model_var: FATES_VEGC_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
@@ -232,7 +210,6 @@ variables:
   cfadDbze94_tavg-h40-hxy-air:
     description: CloudSat Radar Reflectivity
     dims: [lon, lat, alt40, dbze, time]
-    long_name: Emon.cfadDbze94
     sources: [model_var: CFAD_DBZE94_CS]
     table: atmos
     units: '1'
@@ -240,7 +217,6 @@ variables:
   cfadLidarsr532_tavg-h40-hxy-air:
     description: CALIPSO Scattering Ratio
     dims: [lon, lat, alt40, scatratio, time]
-    long_name: Emon.cfadLidarsr532
     sources: [model_var: CFAD_SR532_CAL]
     table: atmos
     units: '1'
@@ -278,7 +254,6 @@ variables:
   clcalipsoice_tavg-h40-hxy-air:
     description: CALIPSO Ice Cloud Fraction
     dims: [lon, lat, alt40, time]
-    long_name: Emon.clcalipsoice
     sources: [model_var: CLDTOT_CAL_ICE]
     table: atmos
     units: '%'
@@ -286,7 +261,6 @@ variables:
   clcalipsoliq_tavg-h40-hxy-air:
     description: CALIPSO Liquid Cloud Fraction
     dims: [lon, lat, alt40, time]
-    long_name: Emon.clcalipsoliq
     sources: [model_var: CLDTOT_CAL_LIQ]
     table: atmos
     units: '%'
@@ -307,14 +281,14 @@ variables:
   climodis_tavg-u-hxy-u:
     description: MODIS Ice Cloud Fraction
     dims: [lon, lat, time]
-    long_name: Emon.climodis
     sources: [model_var: CLIMODIS]
     table: atmos
     units: '%'
 
   clisccp_tavg-p7c-hxy-air:
     description: Percentage cloud cover in optical depth categories.
-    dims: [lon, lat, plev7c, tau, time]
+    dims: [time, plev, lat, lon, tau]
+    levels: {name: plev7c, units: Pa}
     sources: [model_var: FISCCP1_COSP]
     table: atmos
     units: '%'
@@ -332,7 +306,6 @@ variables:
   clt_tavg-u-hxy-lnd:
     description: Total cloud fraction
     dims: [lon, lat, time]
-    long_name: Eday.clt
     sources: [model_var: CLDTOT]
     table: atmos
     units: '%'
@@ -350,7 +323,6 @@ variables:
     description: Convective cloud fraction
     dims: [lon, lat, time]
     formula: CONCLD*100
-    long_name: AERmon.cltc
     sources: [model_var: CONCLD]
     table: atmos
     units: '%'
@@ -378,7 +350,6 @@ variables:
   cltmodis_tavg-u-hxy-u:
     description: Percentage of total cloud cover as seen by the MODIS instrument simulator.
     dims: [lon, lat, time]
-    long_name: Emon.cltmodis
     sources: [model_var: CLTMODIS]
     table: atmos
     units: '%'
@@ -399,7 +370,6 @@ variables:
   clwmodis_tavg-u-hxy-u:
     description: MODIS Liquid Cloud Fraction
     dims: [lon, lat, time]
-    long_name: Emon.clwmodis
     sources: [model_var: CLWMODIS]
     table: atmos
     units: '%'
@@ -410,7 +380,6 @@ variables:
       Includes precipitating hydrometeors ONLY if the precipitating hydrometeor affects
       the calculation of radiative transfer in model.
     dims: [lon, lat, time]
-    long_name: Amon.clwvi
     sources: [model_var: TGCLDCWP]
     table: atmos
     units: kg m-2
@@ -418,7 +387,6 @@ variables:
   cnc_tavg-u-hxy-u:
     description: Canopy covered fraction
     dims: [lon, lat, time]
-    long_name: Emon.cnc
     sources: [model_var: FATES_AREA_PLANTS]
     table: land
     units: '%'
@@ -429,7 +397,6 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    long_name: AERmon.co2
     sources: [model_var: CO2]
     table: atmos
     units: mol mol-1
@@ -437,8 +404,8 @@ variables:
   co2_tavg-p19-hxy-air:
     description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
       where X is a material constituent of Y.
-    dims: [lon, lat, plev19, time]
-    long_name: Amon.co2
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: CO2]
     table: atmos
     units: mol mol-1
@@ -447,7 +414,6 @@ variables:
     description: Total atmospheric mass of Carbon Dioxide
     dims: [time]
     formula: co2vmr*1.5172413793
-    long_name: Amon.co2mass
     sources: [model_var: co2vmr]
     table: atmos
     units: kg
@@ -464,7 +430,6 @@ variables:
       of individual thicknesses of all soil layers.
     dims: [lon, lat]
     formula: sum(DZSOI)
-    long_name: fx.depthsl
     sources: [model_var: DZSOI]
     table: land
     units: m
@@ -473,7 +438,6 @@ variables:
     description: The flux due to conversion of liquid or solid water into vapor at
       the surface where there is snow on land
     dims: [lon, lat, time]
-    long_name: Eday.esn
     sources: [model_var: QSNOEVAP]
     table: land
     units: kg m-2 s-1
@@ -484,7 +448,6 @@ variables:
       to vapor (from underlying surface and vegetation)'
     dims: [lon, lat, time]
     formula: QVEGT+QVEGE+QSOIL
-    long_name: Eday.evspsbl
     sources: [model_var: QVEGT, model_var: QVEGE, model_var: QSOIL]
     table: atmos
     units: kg m-2 s-1
@@ -493,7 +456,6 @@ variables:
     description: at surface; flux of water into the atmosphere due to conversion of
       both liquid and solid phases to vapor (from underlying surface and vegetation)
     dims: [lon, lat, time]
-    long_name: Amon.evspsbl
     sources: [model_var: QFLX]
     table: atmos
     units: kg m-2 s-1
@@ -501,7 +463,6 @@ variables:
   evspsblsoi_tavg-u-hxy-lnd:
     description: includes sublimation.
     dims: [lon, lat, time]
-    long_name: Lmon.evspsblsoi
     sources: [model_var: QSOIL]
     table: land
     units: kg m-2 s-1
@@ -516,7 +477,6 @@ variables:
   evspsblveg_tavg-u-hxy-lnd:
     description: the canopy evaporation+sublimation (if present in model).
     dims: [lon, lat, time]
-    long_name: Lmon.evspsblveg
     sources: [model_var: QVEGE]
     table: land
     units: kg m-2 s-1
@@ -532,7 +492,6 @@ variables:
     description: The fixation (uptake of nitrogen gas directly from the atmosphere)
       of nitrogen due to biological processes.
     dims: [lon, lat, time]
-    long_name: Emon.fBNF
     sources: [model_var: NFIX_TO_SMINN]
     table: land
     units: kg m-2 s-1
@@ -542,7 +501,6 @@ variables:
       its way into ocean should be reported here.
     dims: [lon, lat, time]
     formula: SOM_C_LEACHED *1000
-    long_name: Emon.fCLandToOcean
     sources: [model_var: SOM_C_LEACHED]
     table: land
     units: kg m-2 s-1
@@ -554,7 +512,6 @@ variables:
       to compare deforested biomass across models.
     dims: [lon, lat, time]
     formula: DWT_CROPPROD1C_GAIN+DWT_WOODPRODC_GAIN
-    long_name: Emon.fDeforestToProduct
     sources: [model_var: DWT_CROPPROD1C_GAIN, model_var: DWT_WOODPRODC_GAIN]
     table: land
     units: kg m-2 s-1
@@ -563,7 +520,6 @@ variables:
     description: From all sources,  Including natural, anthropogenic and Land-use
       change. Only total fire emissions can be compared to observations.
     dims: [lon, lat, time]
-    long_name: Emon.fFireAll
     sources: [model_var: FATES_FIRE_CLOSS]
     table: land
     units: kg m-2 s-1
@@ -571,7 +527,6 @@ variables:
   fFireNat_tavg-u-hxy-lnd:
     description: CO2 emissions from natural fires
     dims: [lon, lat, time]
-    long_name: Emon.fFireNat
     sources: [model_var: FATES_FIRE_CLOSS]
     table: land
     units: kg m-2 s-1
@@ -582,7 +537,6 @@ variables:
       any CO2 flux from fire included in fLuc, defined below (CO2 Flux to Atmosphere
       from Land Use Change).
     dims: [lon, lat, time]
-    long_name: Lmon.fFire
     sources: [model_var: FATES_FIRE_CLOSS]
     table: land
     units: kg m-2 s-1
@@ -591,7 +545,6 @@ variables:
     description: Carbon mass flux per unit area into soil from litter (dead plant
       material in or above the soil).
     dims: [lon, lat, time]
-    long_name: Lmon.fLitterSoil
     sources: [model_var: FATES_LITTER_OUT_EL]
     table: land
     units: kg m-2 s-1
@@ -599,7 +552,6 @@ variables:
   fLuc_tavg-u-hxy-lnd:
     description: Net Carbon Mass Flux into Atmosphere due to Land Use Change
     dims: [lon, lat, time]
-    long_name: Emon.fLuc
     sources: [model_var: LAND_USE_FLUX]
     table: land
     units: kg m-2 s-1
@@ -610,7 +562,6 @@ variables:
       carbon transferred due to deforestation or agricultural directly into atmosphere,
       and  emissions form anthropogenic pools into atmosphere
     dims: [lon, lat, landuse, time]
-    long_name: Emon.fLulccAtmLut
     sources: [model_var: DWT_CONV_CFLUX]
     table: land
     units: kg m-2 s-1
@@ -621,7 +572,6 @@ variables:
       soil), soil.
     dims: [lon, lat, time]
     formula: F_N2O_DENIT+F_N2O_NIT
-    long_name: Emon.fN2O
     sources: [model_var: F_N2O_DENIT, model_var: F_N2O_NIT]
     table: land
     units: kg m-2 s-1
@@ -630,7 +580,6 @@ variables:
     description: leached nitrogen etc that goes into run off or river routing and
       finds its way into ocean should be reported here.
     dims: [lon, lat, time]
-    long_name: Emon.fNLandToOcean
     sources: [model_var: SMIN_NO3_LEACHED]
     table: land
     units: kg m-2 s-1
@@ -648,7 +597,6 @@ variables:
       "Litter" is dead plant material in or above the soil.
     dims: [lon, lat, time]
     formula: SMIN_NO3_LEACHED+SMIN_NO3_RUNOFF
-    long_name: Emon.fNOx
     sources: [model_var: SMIN_NO3_LEACHED, model_var: SMIN_NO3_RUNOFF]
     table: land
     units: kg m-2 s-1
@@ -660,7 +608,6 @@ variables:
       to compare deforested biomass across models.
     dims: [lon, lat, time]
     formula: DWT_WOODPRODN_GAIN + DWT_CROPPROD1N_GAIN
-    long_name: Emon.fNProduct
     sources: [model_var: DWT_WOODPRODN_GAIN, model_var: DWT_CROPPROD1N_GAIN]
     table: land
     units: kg m-2 s-1
@@ -668,7 +615,6 @@ variables:
   fNdep_tavg-u-hxy-lnd:
     description: Surface deposition rate of nitrogen.
     dims: [lon, lat, time]
-    long_name: Emon.fNdep
     sources: [model_var: NDEP_TO_SMINN]
     table: land
     units: kg m-2 s-1
@@ -676,7 +622,6 @@ variables:
   fNgasFire_tavg-u-hxy-lnd:
     description: Flux of Nitrogen from the land into the atmosphere due to fire
     dims: [lon, lat, time]
-    long_name: Emon.fNgasFire
     sources: [model_var: COL_FIRE_NLOSS]
     table: land
     units: kg m-2 s-1
@@ -686,7 +631,6 @@ variables:
       other than fire
     dims: [lon, lat, time]
     formula: DENIT+F_N2O_NIT
-    long_name: Emon.fNgasNonFire
     sources: [model_var: DENIT, model_var: F_N2O_NIT]
     table: land
     units: kg m-2 s-1
@@ -695,7 +639,6 @@ variables:
     description: Total flux of Nitrogen from the land into the atmosphere.
     dims: [lon, lat, time]
     formula: DENIT+F_N2O_NIT+COL_FIRE_NLOSS
-    long_name: Emon.fNgas
     sources: [model_var: DENIT, model_var: F_N2O_NIT, model_var: COL_FIRE_NLOSS]
     table: land
     units: kg m-2 s-1
@@ -710,7 +653,6 @@ variables:
       specified, "runoff" refers to the sum of surface runoff and subsurface drainage.
     dims: [lon, lat, time]
     formula: SMIN_NO3_LEACHED+ SMIN_NO3_RUNOFF
-    long_name: Emon.fNleach
     sources: [model_var: SMIN_NO3_LEACHED, model_var: SMIN_NO3_RUNOFF]
     table: land
     units: kg m-2 s-1
@@ -719,7 +661,6 @@ variables:
     description: Not all models split losses into gaseous and leaching
     dims: [lon, lat, time]
     formula: DENIT+ F_N2O_NIT+ SMIN_NO3_LEACHED + SMIN_NO3_RUNOFF
-    long_name: Emon.fNloss
     sources: [model_var: DENIT, model_var: F_N2O_NIT, model_var: SMIN_NO3_LEACHED,
       model_var: SMIN_NO3_RUNOFF]
     table: land
@@ -732,7 +673,6 @@ variables:
       and releases energy. Immobilisation of nitrogen refers to retention of nitrogen
       by micro-organisms under certain conditions, making it unavailable for plants.
     dims: [lon, lat, time]
-    long_name: Emon.fNnetmin
     sources: [model_var: NET_NMIN]
     table: land
     units: kg m-2 s-1
@@ -746,7 +686,6 @@ variables:
       when the products decompose in landfill sites.
     dims: [lon, lat, time]
     formula: TOT_WOODPRODC_LOSS+CROPPROD1C_LOSS
-    long_name: Emon.fProductDecomp
     sources: [model_var: TOT_WOODPRODC_LOSS, model_var: CROPPROD1C_LOSS]
     table: land
     units: kg m-2 s-1
@@ -755,7 +694,6 @@ variables:
     description: Required for unambiguous separation of vegetation and soil + litter
       turnover times, since total fire flux draws from both sources
     dims: [lon, lat, time]
-    long_name: Emon.fVegFire
     sources: [model_var: FATES_FIRE_CLOSS]
     table: land
     units: kg m-2 s-1
@@ -765,7 +703,6 @@ variables:
       from changing allocation versus changing mortality
     dims: [lon, lat, time]
     formula: (FATES_MORTALITY_CFLUX_CANOPY+FATES_MORTALITY_CFLUX_USTORY)*FATES_FRACTION
-    long_name: Emon.fVegLitterMortality
     sources: [model_var: FATES_MORTALITY_CFLUX_CANOPY, model_var: FATES_MORTALITY_CFLUX_USTORY,
       model_var: FATES_FRACTION]
     table: land
@@ -776,7 +713,6 @@ variables:
       from changing allocation versus changing mortality
     dims: [lon, lat, time]
     formula: (FATES_LITTER_IN_EL-FATES_MORTALITY_CFLUX_CANOPY+FATES_MORTALITY_CFLUX_USTORY)*FATES_FRACTION
-    long_name: Emon.fVegLitterSenescence
     sources: [model_var: FATES_LITTER_IN_EL, model_var: FATES_MORTALITY_CFLUX_CANOPY,
       model_var: FATES_MORTALITY_CFLUX_USTORY, model_var: FATES_FRACTION]
     table: land
@@ -791,7 +727,6 @@ variables:
       standard names mass_flux_of_carbon_into_litter_from_vegetation_due_to_mortality
       and mass_flux_of_carbon_into_litter_from_vegetation_due_to_senescence is mass_flux_of_carbon_into_litter_from_vegetation.
     dims: [lon, lat, time]
-    long_name: Lmon.fVegLitter
     sources: [model_var: FATES_LITTER_IN_EL]
     table: land
     units: kg m-2 s-1
@@ -801,7 +736,6 @@ variables:
       from changing allocation versus changing mortality
     dims: [lon, lat, time]
     formula: (FATES_MORTALITY_CFLUX_CANOPY+FATES_MORTALITY_CFLUX_USTORY)*FATES_FRACTION
-    long_name: Emon.fVegSoilMortality
     sources: [model_var: FATES_MORTALITY_CFLUX_CANOPY, model_var: FATES_MORTALITY_CFLUX_USTORY,
       model_var: FATES_FRACTION]
     table: land
@@ -810,7 +744,6 @@ variables:
     description: Cumulative percentage transitions over the year; note that percentage
       should be reported as a percentage of atmospheric grid cell
     dims: [lon, lat, landuse, time]
-    long_name: Eyr.fracInLut
     sources: [model_var: FATES_TRANSITION_MATRIX_LULU]
     table: land
     units: '%'
@@ -818,7 +751,6 @@ variables:
     description: Cumulative percentage transitions over the year; note that percentage
       should be reported as percentage of atmospheric grid cell
     dims: [lon, lat, landuse, time]
-    long_name: Eyr.fracOutLut
     sources: [model_var: FATES_TRANSITION_MATRIX_LULU]
     table: land
     units: '%'
@@ -830,7 +762,6 @@ variables:
       this biomass and the difference is referred to as the net primary production.
       Reported on land-use tiles.
     dims: [lon, lat, landuse, time]
-    long_name: Emon.gppLut
     sources: [model_var: FATES_GPP_LU]
     table: land
     units: kg m-2 s-1
@@ -841,7 +772,6 @@ variables:
       photosynthesis in plants or phytoplankton. The producers also respire some of
       this biomass and the difference is referred to as the net primary production.
     dims: [lon, lat, time]
-    long_name: Lmon.gpp
     sources: [model_var: FATES_GPP]
     table: land
     units: kg m-2 s-1
@@ -850,7 +780,6 @@ variables:
     description: Total GPP of grass in the grid cell
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[12, 13, 14], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.gppGrass
     sources: [model_var: FATES_GPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -859,7 +788,6 @@ variables:
     description: Total GPP of shrubs in the grid cell
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[7, 8, 9, 10, 11], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.gppShrub
     sources: [model_var: FATES_GPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -868,7 +796,6 @@ variables:
     description: Total GPP of trees in the grid cell
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.gppTree
     sources: [model_var: FATES_GPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -877,7 +804,6 @@ variables:
     description: Percentage of entire grid cell covered by C3 natural grass.
     dims: [lon, lat, time, typec3natg]
     formula: (FATES_CROWNAREA_PF(12+13))*FATES_FRACTION
-    long_name: Emon.grassFracC3
     sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -886,7 +812,6 @@ variables:
     description: Percentage of entire grid cell covered by C4 natural grass.
     dims: [lon, lat, time, typec4natg]
     formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[14], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.grassFracC4
     sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -901,7 +826,6 @@ variables:
   hfdsl_tavg-u-hxy-lnd:
     description: Ground heat flux at 3hr
     dims: [lon, lat, time]
-    long_name: 3hr.hfdsl
     sources: [model_var: FGR]
     table: land
     units: W m-2
@@ -933,8 +857,8 @@ variables:
   hur_tavg-p19-hxy-air:
     description: This is the relative humidity with respect to liquid water for T>
       0 C, and with respect to ice for T<0 C.
-    dims: [lon, lat, plev19, time]
-    long_name: Amon.hur
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: RELHUM, model_var: RHW]
     table: atmos
     units: '%'
@@ -942,8 +866,8 @@ variables:
   hur_tavg-p19-hxy-u:
     description: This is the relative humidity with respect to liquid water for T>
       0 C, and with respect to ice for T<0 C.
-    dims: [lon, lat, plev19, time]
-    long_name: day.hur
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: RELHUM]
     table: atmos
     units: '%'
@@ -960,7 +884,6 @@ variables:
     description: This is the relative humidity with respect to liquid water for T>
       0 C, and with respect to ice for T<0 C.
     dims: [lon, lat, time, height2m]
-    long_name: day.hursmax
     sources: [{model_var: 'X: RHREFHT'}]
     table: atmos
     units: '%'
@@ -978,7 +901,8 @@ variables:
   hus_tavg-p19-hxy-u:
     description: Specific humidity is the mass fraction of water vapor in (moist)
       air.
-    dims: [lon, lat, plev19, time]
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: Q]
     table: atmos
     units: '1'
@@ -1004,7 +928,6 @@ variables:
       lakes, urban areas, etc.   Sum of all should equal the fraction of the grid-cell
       that is land.
     dims: [lon, lat, vegtype, time]
-    long_name: Lmon.landCoverFrac
     sources: [model_var: PCT_LANDUNIT]
     table: land
     units: '%'
@@ -1013,7 +936,6 @@ variables:
     description: The total dry mass of black carbon aerosol particles per unit area.
     dims: [lon, lat, time]
     formula: BC_A+BC_AC+BC_AI+BC_AX+BC_N+BC_NI
-    long_name: Eday.loadbc
     sources: [model_var: BC_A, model_var: BC_AC, model_var: BC_AI, model_var: BC_AX,
       model_var: BC_N, model_var: BC_NI]
     table: atmos
@@ -1023,7 +945,6 @@ variables:
     description: The total dry mass of dust aerosol particles per unit area.
     dims: [lon, lat, time]
     formula: DST_A2+DST_A3
-    long_name: Eday.loaddust
     sources: [model_var: DST_A2, model_var: DST_A3]
     table: atmos
     units: kg m-2
@@ -1032,7 +953,6 @@ variables:
     description: The total dry mass of sulfate aerosol particles per unit area.
     dims: [lon, lat, time]
     formula: SO4_A1*3+SO4_A2*3+SO4_AC*3+SO4_N*3+SO4_NA*3+SO4_PR*3
-    long_name: Eday.loadso4
     sources: [model_var: SO4_A1, model_var: SO4_A2, model_var: SO4_AC, model_var: SO4_N,
       model_var: SO4_NA, model_var: SO4_PR]
     table: atmos
@@ -1042,7 +962,6 @@ variables:
     description: The total dry mass of sea salt aerosol particles per unit area.
     dims: [lon, lat, time]
     formula: SS_A1+SS_A2+SS_A3
-    long_name: Eday.loadss
     sources: [model_var: SS_A1, model_var: SS_A2, model_var: SS_A3]
     table: atmos
     units: kg m-2
@@ -1053,7 +972,6 @@ variables:
       of the grid cell.
     dims: [lon, lat, alevhalf, time]
     formula: CMFMC+CMFMCDZM
-    long_name: Amon.mc
     sources: [model_var: CMFMC, model_var: CMFMCDZM]
     table: atmos
     units: kg m-2 s-1
@@ -1070,7 +988,6 @@ variables:
   mrrob_tavg-u-hxy-lnd:
     description: subsurface_runoff_flux
     dims: [lon, lat, time]
-    long_name: Eday.mrrob
     sources: [model_var: QDRAI]
     table: land
     units: kg m-2 s-1
@@ -1111,7 +1028,6 @@ variables:
       all the soil in the grid cell by the land area in the grid cell;  reported as
       "missing" where the land fraction is 0.'
     dims: [lon, lat]
-    long_name: fx.mrsofc
     sources: [model_var: SUCSAT]
     table: land
     units: kg m-2
@@ -1142,7 +1058,6 @@ variables:
     description: Report missing data over ocean grid cells. For fractional land report
       value averaged over the land fraction.
     dims: [lon, lat, time]
-    long_name: Emon.nLand
     sources: [model_var: TOTECOSYSN]
     table: land
     units: kg m-2
@@ -1150,7 +1065,6 @@ variables:
   nMineralNH4_tavg-u-hxy-lnd:
     description: SUM of ammonium over all soil layers
     dims: [lon, lat, time]
-    long_name: Emon.nMineralNH4
     sources: [model_var: SMIN_NH4]
     table: land
     units: kg m-2
@@ -1158,7 +1072,6 @@ variables:
   nMineralNO3_tavg-u-hxy-lnd:
     description: SUM of nitrate over all soil layers
     dims: [lon, lat, time]
-    long_name: Emon.nMineralNO3
     sources: [model_var: SMIN_NO3]
     table: land
     units: kg m-2
@@ -1166,7 +1079,6 @@ variables:
   nMineral_tavg-u-hxy-lnd:
     description: SUM of ammonium, nitrite, nitrate, etc over all soil layers
     dims: [lon, lat, time]
-    long_name: Emon.nMineral
     sources: [model_var: SMINN]
     table: land
     units: kg m-2
@@ -1176,7 +1088,6 @@ variables:
       value averaged over the land fraction.
     dims: [lon, lat, time]
     formula: SOIL1N+SOIL2N+SOIL3N
-    long_name: Emon.nSoil
     sources: [model_var: SOIL1N, model_var: SOIL2N, model_var: SOIL3N]
     table: land
     units: kg m-2
@@ -1187,7 +1098,6 @@ variables:
       fire, harvest, grazing  and land use change. Positive flux  is into the land.
     dims: [lon, lat, time]
     formula: FCO2 /1000 / conv
-    long_name: Lmon.nbp
     sources: [model_var: FCO2, model_var: conv]
     table: land
     units: kg m-2 s-1
@@ -1195,7 +1105,6 @@ variables:
   nep_tavg-u-hxy-lnd:
     description: Net Ecosystem Exchange
     dims: [lon, lat, time]
-    long_name: Emon.nep
     sources: [model_var: NEP]
     table: land
     units: kg m-2 s-1
@@ -1203,7 +1112,6 @@ variables:
   nppLeaf_tavg-u-hxy-lnd:
     description: This is the rate of carbon uptake by leaves due to NPP
     dims: [lon, lat, time]
-    long_name: Lmon.nppLeaf
     sources: [model_var: FATES_LEAF_ALLOC]
     table: land
     units: kg m-2 s-1
@@ -1220,7 +1128,6 @@ variables:
       solely with respect to the B contained in A, neglecting all other chemical constituents
       of A.'
     dims: [lon, lat, landuse, time]
-    long_name: Emon.nppLut
     sources: [model_var: FATES_NPP_LU]
     table: land
     units: kg m-2 s-1
@@ -1229,7 +1136,6 @@ variables:
     description: added for completeness with npp_root
     dims: [lon, lat, time]
     formula: (FATES_SEED_ALLOC+FATES_STORE_ALLOC)*FATES_FRACTION
-    long_name: Emon.nppOther
     sources: [model_var: FATES_SEED_ALLOC, model_var: FATES_STORE_ALLOC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1238,7 +1144,6 @@ variables:
     description: This is the rate of carbon uptake by roots due to NPP
     dims: [lon, lat, time]
     formula: (FATES_CROOT_ALLOC+FATES_FROOT_ALLOC)*FATES_FRACTION
-    long_name: Lmon.nppRoot
     sources: [model_var: FATES_CROOT_ALLOC, model_var: FATES_FROOT_ALLOC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1246,7 +1151,6 @@ variables:
   nppStem_tavg-u-hxy-lnd:
     description: added for completeness with npp_root
     dims: [lon, lat, time]
-    long_name: Emon.nppStem
     sources: [model_var: FATES_STEM_ALLOC]
     table: land
     units: kg m-2 s-1
@@ -1263,7 +1167,6 @@ variables:
       solely with respect to the B contained in A, neglecting all other chemical constituents
       of A.'
     dims: [lon, lat, time]
-    long_name: Lmon.npp
     sources: [model_var: FATES_NPP]
     table: land
     units: kg m-2 s-1
@@ -1272,7 +1175,6 @@ variables:
     description: Total NPP of grass in the grid cell
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_NPP_PF, pftlist=[12, 13, 14], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.nppGrass
     sources: [model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1281,7 +1183,6 @@ variables:
     description: Total NPP of shrubs in the grid cell
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_NPP_PF, pftlist=[7, 8, 9, 10, 11], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.nppShrub
     sources: [model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1290,7 +1191,6 @@ variables:
     description: Total NPP of trees in the grid cell
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_NPP_PF, pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.nppTree
     sources: [model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1311,7 +1211,6 @@ variables:
       of the ocean changes (e.g., due to glacial melt, or global warming of the ocean).  Reported
       here is the height above the present-day geoid (0.0 over ocean).
     dims: [lon, lat]
-    long_name: fx.orog
     sources: [model_var: PHIS]
     table: land
     units: m
@@ -1320,7 +1219,6 @@ variables:
     description: fraction of entire grid cell  that is covered by anthropogenic pasture.
     dims: [lon, lat, time, typepasture]
     formula: (sumoverpft(FATES_PATCHAREA_LU, pftlist=[4], dim='fates_levlanduse'))*FATES_FRACTION
-    long_name: Lmon.pastureFrac
     sources: [model_var: FATES_PATCHAREA_LU, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -1351,7 +1249,6 @@ variables:
     description: rainfall_flux
     dims: [lon, lat, time]
     formula: PRECT-PRECSC-PRECSL
-    long_name: Eday.prra
     sources: [model_var: PRECT, model_var: PRECSC, model_var: PRECSL]
     table: atmos
     units: kg m-2 s-1
@@ -1368,7 +1265,6 @@ variables:
     description: the precipitation flux that is intercepted by the vegetation canopy
       (if present in model) before reaching the ground.
     dims: [lon, lat, time]
-    long_name: Lmon.prveg
     sources: [model_var: QINTR]
     table: land
     units: kg m-2 s-1
@@ -1400,7 +1296,6 @@ variables:
     description: 2D monthly mean thermal tropopause calculated using WMO tropopause
       definition on 3d temperature
     dims: [lon, lat, time]
-    long_name: AERmon.ptp
     sources: [model_var: TROP_P]
     table: atmos
     units: Pa
@@ -1408,7 +1303,6 @@ variables:
   qgwr_tavg-u-hxy-lnd:
     description: water_flux_from_soil_layer_to_groundwater
     dims: [lon, lat, time]
-    long_name: Eday.qgwr
     sources: [model_var: QCHARGE]
     table: land
     units: kg m-2 s-1
@@ -1416,7 +1310,6 @@ variables:
   raLeaf_tavg-u-hxy-lnd:
     description: added for completeness with Ra_root
     dims: [lon, lat, time]
-    long_name: Emon.raLeaf
     sources: [model_var: FATES_LEAFMAINTAR]
     table: land
     units: kg m-2 s-1
@@ -1427,7 +1320,6 @@ variables:
       Calculated on land-use tiles.
     dims: [lon, lat, landuse, time]
     formula: (FATES_GPP_LU-FATES_NPP_LU)*FATES_FRACTION
-    long_name: Emon.raLut
     sources: [model_var: FATES_GPP_LU, model_var: FATES_NPP_LU, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1438,7 +1330,6 @@ variables:
       to observations of total soil respiration.
     dims: [lon, lat, time]
     formula: FROOTMAINTAR+CROOTMAINTAR
-    long_name: Emon.raRoot
     sources: [model_var: FROOTMAINTAR, model_var: CROOTMAINTAR]
     table: land
     units: kg m-2 s-1
@@ -1446,7 +1337,6 @@ variables:
   raStem_tavg-u-hxy-lnd:
     description: added for completeness with Ra_root
     dims: [lon, lat, time]
-    long_name: Emon.raStem
     sources: [model_var: FATES_LSTEMMAINTAR]
     table: land
     units: kg m-2 s-1
@@ -1456,7 +1346,6 @@ variables:
       respiration on land (respiration by producers) [see rh for heterotrophic production].
       Calculated on vegetation type.
     dims: [lon, lat, vegtype, time]
-    long_name: Eday.raVgt
     sources: [model_var: FATES_AUTORESP]
     table: land
     units: kg m-2 s-1
@@ -1466,7 +1355,6 @@ variables:
       respiration on land (respiration by producers) [see rh for heterotrophic production]
     dims: [lon, lat, time]
     formula: FATES_AUTORESP*FATES_FRACTIONTION
-    long_name: Lmon.ra
     sources: [model_var: FATES_AUTORESP, model_var: FATES_FRACTIONTION]
     table: land
     units: kg m-2 s-1
@@ -1476,7 +1364,6 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[12, 13, 14], dim='fates_levpft')-sumoverpft(FATES_NPP_PF,
       pftlist=[12, 13, 14], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.raGrass
     sources: [model_var: FATES_GPP_PF, model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1486,7 +1373,6 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[7, 8, 9, 10, 11], dim='fates_levpft')-sumoverpft(FATES_NPP_PF,
       pftlist=[7, 8, 9, 10, 11], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.raShrub
     sources: [model_var: FATES_GPP_PF, model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1496,7 +1382,6 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft')-sumoverpft(FATES_NPP_PF,
       pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.raTree
     sources: [model_var: FATES_GPP_PF, model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1509,7 +1394,6 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    long_name: Emon.reffclws
     sources: [model_var: REFFL]
     table: atmos
     units: m
@@ -1527,7 +1411,6 @@ variables:
       from CWD as well.
     dims: [lon, lat, time]
     formula: LITTERC_HR /1000
-    long_name: Emon.rhLitter
     sources: [model_var: LITTERC_HR]
     table: land
     units: kg m-2 s-1
@@ -1536,7 +1419,6 @@ variables:
     description: Needed to calculate soil bulk turnover time
     dims: [lon, lat, time]
     formula: SOILC_HR /1000
-    long_name: Emon.rhSoil
     sources: [model_var: SOILC_HR]
     table: land
     units: kg m-2 s-1
@@ -1545,7 +1427,6 @@ variables:
     description: Carbon mass flux per unit area into atmosphere due to heterotrophic
       respiration on land (respiration by consumers), calculated on vegetation type.
     dims: [lon, lat, vegtype, time]
-    long_name: Eday.rhVgt
     sources: [model_var: FATES_HET_RESP]
     table: land
     units: kg m-2 s-1
@@ -1555,7 +1436,6 @@ variables:
       respiration on land (respiration by consumers)
     dims: [lon, lat, time]
     formula: FATES_HET_RESP*FATES_FRACTION
-    long_name: Lmon.rh
     sources: [model_var: FATES_HET_RESP, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -1563,7 +1443,6 @@ variables:
   rldcs_tavg-alh-hxy-u:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
-    long_name: CFmon.rldcs
     sources: [model_var: FDLC]
     table: atmos
     units: W m-2
@@ -1585,7 +1464,6 @@ variables:
   rls_tavg-u-hxy-u:
     description: Net longwave surface radiation
     dims: [lon, lat, time]
-    long_name: Emon.rls
     sources: [model_var: FLNS]
     table: atmos
     units: W m-2
@@ -1593,7 +1471,6 @@ variables:
   rlu_tavg-alh-hxy-u:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
-    long_name: CFmon.rlu
     sources: [model_var: FUL]
     table: atmos
     units: W m-2
@@ -1601,7 +1478,6 @@ variables:
   rlucs_tavg-alh-hxy-u:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
-    long_name: CFmon.rlucs
     sources: [model_var: FULC]
     table: atmos
     units: W m-2
@@ -1616,7 +1492,6 @@ variables:
   rluscs_tavg-u-hxy-u:
     description: Surface Upwelling Clear-sky Longwave Radiation
     dims: [lon, lat, time]
-    long_name: Amon.rluscs
     sources: [model_var: FULC]
     table: atmos
     units: W m-2
@@ -1638,7 +1513,6 @@ variables:
   rsd_tavg-alh-hxy-u:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
-    long_name: CFmon.rsd
     sources: [model_var: FDS]
     table: atmos
     units: W m-2
@@ -1646,7 +1520,6 @@ variables:
   rsdcs_tavg-alh-hxy-u:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
-    long_name: CFmon.rsdcs
     sources: [model_var: FDSC]
     table: atmos
     units: W m-2
@@ -1655,7 +1528,6 @@ variables:
     description: Surface Downwelling Shortwave Radiation over land. Can be used for
       computation of surface albedo.
     dims: [lon, lat, time]
-    long_name: Emon.rsds
     sources: [model_var: FSDS]
     table: land
     units: W m-2
@@ -1665,7 +1537,6 @@ variables:
       grid cell covered by snow but not by ice. Can be used for computation of surface
       albedo.
     dims: [lon, lat, time]
-    long_name: Emon.rsdss
     sources: [model_var: FSDS]
     table: land
     units: W m-2
@@ -1689,7 +1560,6 @@ variables:
       calculations.
     dims: [lon, lat, time]
     formula: SOLLD+SOLSD
-    long_name: Eday.rsdsdiff
     sources: [model_var: SOLLD, model_var: SOLSD]
     table: atmos
     units: W m-2
@@ -1704,7 +1574,6 @@ variables:
   rss_tavg-u-hxy-u:
     description: Net downward shortwave radiation at the surface
     dims: [lon, lat, time]
-    long_name: Emon.rss
     sources: [model_var: FSNS]
     table: atmos
     units: W m-2
@@ -1712,7 +1581,6 @@ variables:
   rsu_tavg-alh-hxy-u:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
-    long_name: CFmon.rsu
     sources: [model_var: FUS]
     table: atmos
     units: W m-2
@@ -1720,7 +1588,6 @@ variables:
   rsucs_tavg-alh-hxy-u:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
-    long_name: CFmon.rsucs
     sources: [model_var: FUSC]
     table: atmos
     units: W m-2
@@ -1729,7 +1596,6 @@ variables:
     description: Surface Upwelling Shortwave Radiation over land. Can be used for
       computation of surface albedo.
     dims: [lon, lat, time]
-    long_name: Emon.rsus
     sources: [model_var: FSR]
     table: land
     units: W m-2
@@ -1739,7 +1605,6 @@ variables:
       grid cell covered by snow. Can be used for computation of surface albedo.
     dims: [lon, lat, time]
     formula: SNOFSRVI+SNOFSRVD+SNOFSRNI+SNOFSRND
-    long_name: Emon.rsuss
     sources: [model_var: SNOFSRVI, model_var: SNOFSRVD, model_var: SNOFSRNI,
       model_var: SNOFSRND]
     table: land
@@ -1779,7 +1644,6 @@ variables:
       the net downward radiative flux at the top of the atmosphere.
     dims: [lon, lat, time]
     formula: FSNT-FLNT
-    long_name: Amon.rtmt
     sources: [model_var: FSNT, model_var: FLNT]
     table: atmos
     units: W m-2
@@ -1796,7 +1660,6 @@ variables:
       ice cap, glacier)
     dims: [lon, lat, time]
     formula: sumoverpft(PCT_LANDUNIT, pftlist=[4], dim='ltype')
-    long_name: LImon.sftgif
     sources: [model_var: PCT_LANDUNIT]
     table: land
     units: '%'
@@ -1804,7 +1667,6 @@ variables:
   sftlf_ti-u-hxy-u:
     description: Percentage of horizontal area occupied by land.
     dims: [lon, lat]
-    long_name: fx.sftlf
     sources: [model_var: LANDFRAC]
     table: atmos
     units: '%'
@@ -1819,7 +1681,6 @@ variables:
   slthick_ti-sl-hxy-lnd:
     description: Thickness of Soil Layers
     dims: [lon, lat, sdepth]
-    long_name: Efx.slthick
     sources: [model_var: DZSOI]
     table: land
     units: m
@@ -1829,7 +1690,6 @@ variables:
       storage (i.e. lakes, river channel or depression storage).
     dims: [lon, lat, time]
     formula: H2OSFC+ VOLR
-    long_name: Eday.sw
     sources: [model_var: H2OSFC, model_var: VOLR]
     table: land
     units: kg m-2
@@ -1843,7 +1703,6 @@ variables:
       canopy.
     dims: [lon, lat, landuse, time]
     formula: SNOWICE+SNOWLIQ
-    long_name: Emon.sweLut
     sources: [model_var: SNOWICE, model_var: SNOWLIQ]
     table: land
     units: m
@@ -1851,7 +1710,6 @@ variables:
   ta_tavg-700hPa-hxy-air:
     description: Air temperature at 700hPa
     dims: [lon, lat, time, p700]
-    long_name: CFday.ta700
     sources: [model_var: T700]
     table: atmos
     units: K
@@ -1859,7 +1717,6 @@ variables:
   ta_tavg-850hPa-hxy-air:
     description: Air temperature at 850hPa
     dims: [lon, lat, time, p850]
-    long_name: Eday.ta850
     sources: [model_var: T850]
     table: atmos
     units: K
@@ -1875,14 +1732,16 @@ variables:
 
   ta_tavg-p19-hxy-air:
     description: Air Temperature
-    dims: [lon, lat, plev19, time]
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: T]
     table: atmos
     units: K
 
   ta_tavg-p39-hy-air:
     description: Air Temperature
-    dims: [lat, plev39, time]
+    dims: [time, plev, lat]
+    levels: {name: plev39, units: Pa}
     sources: [model_var: T]
     table: atmos
     units: K
@@ -1891,7 +1750,6 @@ variables:
     description: Air temperature is the bulk temperature of the air, not the surface
       (skin) temperature.
     dims: [lon, lat, landuse, time, height2m]
-    long_name: Emon.tasLut
     sources: [model_var: TSA]
     table: land
     units: K
@@ -1914,7 +1772,6 @@ variables:
     description: 'maximum near-surface (usually, 2 meter) air temperature (add cell_method
       attribute "time: max")'
     dims: [lon, lat, time, height2m]
-    long_name: day.tasmax
     sources: [model_var: TREFHTMX]
     table: atmos
     units: K
@@ -1922,7 +1779,6 @@ variables:
   tas_tmaxavg-h2m-hxy-u:
     description: monthly mean of the daily-maximum near-surface air temperature.
     dims: [lon, lat, time4, height2m]
-    long_name: Amon.tasmax
     sources: [model_var: TREFMXAV]
     table: atmos
     units: K
@@ -1931,7 +1787,6 @@ variables:
     description: 'minimum near-surface (usually, 2 meter) air temperature (add cell_method
       attribute "time: min")'
     dims: [lon, lat, time, height2m]
-    long_name: day.tasmin
     sources: [model_var: TREFHTMN]
     table: atmos
     units: K
@@ -1955,7 +1810,6 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    long_name: CFmon.tnta
     sources: [model_var: DTCORE]
     table: atmos
     units: K s-1
@@ -1965,7 +1819,6 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    long_name: AERmon.tntrl
     sources: [model_var: QRL]
     table: atmos
     units: K s-1
@@ -1975,7 +1828,6 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    long_name: AERmon.tntrs
     sources: [model_var: QRS]
     table: atmos
     units: K s-1
@@ -1983,7 +1835,6 @@ variables:
   tran_tavg-u-hxy-lnd:
     description: Transpiration (may include dew formation as a negative flux).
     dims: [lon, lat, time]
-    long_name: Lmon.tran
     sources: [model_var: QVEGT]
     table: land
     units: kg m-2 s-1
@@ -1991,7 +1842,6 @@ variables:
   tran_tavg-u-hxy-u:
     description: Transpiration
     dims: [lon, lat, time]
-    long_name: 3hr.tran
     sources: [model_var: QVEGT]
     table: land
     units: kg m-2 s-1
@@ -2001,7 +1851,6 @@ variables:
       broadleaf deciduous trees.
     dims: [lon, lat, time, typetreebd]
     formula: (FATES_CROWNAREA_PF(5:6)*FATES_FRACTION
-    long_name: Emon.treeFracBdlDcd
     sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -2011,7 +1860,6 @@ variables:
       broadleaf evergreen trees.
     dims: [lon, lat, time, typetreebe]
     formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[1, 4], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.treeFracBdlEvg
     sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -2021,7 +1869,6 @@ variables:
       needleleaf deciduous trees.
     dims: [lon, lat, time, typetreend]
     formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[3], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.treeFracNdlDcd
     sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -2031,7 +1878,6 @@ variables:
       needleleaf evergreen trees.
     dims: [lon, lat, time, typetreene]
     formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[2], dim='fates_levpft'))*FATES_FRACTION
-    long_name: Emon.treeFracNdlEvg
     sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -2047,7 +1893,6 @@ variables:
     description: Surface temperature (i.e. temperature at which long-wave radiation
       emitted)
     dims: [lon, lat, landuse, time]
-    long_name: Emon.tslsiLut
     sources: [model_var: TSKIN]
     table: land
     units: K
@@ -2070,7 +1915,6 @@ variables:
   tslsi_tavg-u-hxy-u:
     description: Surface temperature of all surfaces except open ocean.
     dims: [lon, lat, time]
-    long_name: day.tslsi
     sources: [model_var: TSA]
     table: land
     units: K
@@ -2086,14 +1930,16 @@ variables:
 
   ua_tavg-p19-hxy-air:
     description: Zonal wind (positive in a eastward direction).
-    dims: [lon, lat, plev19, time]
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: U]
     table: atmos
     units: m s-1
 
   ua_tavg-p39-hy-air:
     description: Zonal wind (positive in a eastward direction).
-    dims: [lat, plev39, time]
+    dims: [time, plev, lat]
+    levels: {name: plev39, units: Pa}
     sources: [model_var: U]
     table: atmos
     units: m s-1
@@ -2109,15 +1955,16 @@ variables:
 
   va_tavg-p19-hxy-air:
     description: Meridional wind (positive in a northward direction).
-    dims: [lon, lat, plev19, time]
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: V]
     table: atmos
     units: m s-1
 
   va_tavg-p39-hy-air:
     description: Meridional wind (positive in a northward direction).
-    dims: [lat, plev39, time]
-    long_name: AERmonZ.va
+    dims: [time, plev, lat]
+    levels: {name: plev39, units: Pa}
     sources: [model_var: V]
     table: atmos
     units: m s-1
@@ -2133,7 +1980,6 @@ variables:
   vegHeight_tavg-u-hxy-ng:
     description: Vegetation height averaged over the grass fraction of a grid cell.
     dims: [lon, lat, time]
-    long_name: Emon.vegHeightGrass
     sources: [model_var: FATES_CA_WEIGHTED_HEIGHT]
     table: land
     units: m
@@ -2142,7 +1988,6 @@ variables:
     description: Vegetation height averaged over all vegetation types and over the
       vegetated fraction of a grid cell.
     dims: [lon, lat, time]
-    long_name: Emon.vegHeight
     sources: [model_var: FATES_CA_WEIGHTED_HEIGHT]
     table: land
     units: m
@@ -2151,7 +1996,6 @@ variables:
     description: at 500 hPa level; commonly referred to as "omega", this represents
       the vertical component of velocity in pressure coordinates (positive down)
     dims: [lon, lat, time, p500]
-    long_name: CFday.wap500
     sources: [model_var: OMEGA500]
     table: atmos
     units: Pa s-1
@@ -2162,7 +2006,6 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    long_name: CFday.wap
     sources: [model_var: OMEGA]
     table: atmos
     units: Pa s-1
@@ -2170,8 +2013,8 @@ variables:
   wap_tavg-p19-hxy-air:
     description: commonly referred to as "omega", this represents the vertical component
       of velocity in pressure coordinates (positive down)
-    dims: [lon, lat, plev19, time]
-    long_name: Amon.wap
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: OMEGA]
     table: atmos
     units: Pa s-1
@@ -2179,8 +2022,8 @@ variables:
   wap_tavg-p19-hxy-u:
     description: commonly referred to as "omega", this represents the vertical component
       of velocity in pressure coordinates (positive down)
-    dims: [lon, lat, plev19, time]
-    long_name: day.wap
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: OMEGA]
     table: atmos
     units: Pa s-1
@@ -2191,7 +2034,6 @@ variables:
       year or for varying periods of time during the year, including during the growing
       season).
     dims: [lon, lat, time]
-    long_name: Emon.wetlandCH4
     sources: [model_var: FCH4]
     table: land
     units: kg m-2 s-1
@@ -2202,7 +2044,6 @@ variables:
       of the soil all year or for varying periods of time during the year, including
       during the growing season).
     dims: [lon, lat, time]
-    long_name: Emon.wetlandCH4prod
     sources: [model_var: CH4PROD]
     table: land
     units: kg m-2 s-1
@@ -2211,7 +2052,6 @@ variables:
     description: Percentage of grid cell covered by wetland. Report only one year
       if  fixed percentage is used, or time series if values are determined dynamically.
     dims: [lon, lat, time, typewetla]
-    long_name: Emon.wetlandFrac
     sources: [model_var: FINUNDATED]
     table: land
     units: '%'
@@ -2219,7 +2059,6 @@ variables:
   wtd_tavg-u-hxy-lnd:
     description: depth_of_soil_moisture_saturation
     dims: [lon, lat, time]
-    long_name: Eday.wtd
     sources: [model_var: ZWT]
     table: land
     units: m
@@ -2234,7 +2073,6 @@ variables:
   zg_tavg-500hPa-hxy-air:
     description: geopotential height on the 500 hPa surface
     dims: [lon, lat, time, p500]
-    long_name: AERday.zg500
     sources: [model_var: Z500]
     table: atmos
     units: m
@@ -2258,7 +2096,8 @@ variables:
       height is the geopotential divided by the standard acceleration due to gravity.
       It is numerically similar to the altitude (or geometric height) and not to the
       quantity with standard name height, which is relative to the surface.
-    dims: [lon, lat, plev19, time]
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
     sources: [model_var: Z3]
     table: atmos
     units: m
@@ -2269,7 +2108,8 @@ variables:
       height is the geopotential divided by the standard acceleration due to gravity.
       It is numerically similar to the altitude (or geometric height) and not to the
       quantity with standard name height, which is relative to the surface.
-    dims: [lat, plev39, time]
+    dims: [time, plev, lat]
+    levels: {name: plev39, units: Pa}
     sources: [model_var: Z3]
     table: atmos
     units: m
@@ -2278,7 +2118,6 @@ variables:
     description: 2D monthly mean thermal tropopause calculated using WMO tropopause
       definition on 3d temperature
     dims: [lon, lat, time]
-    long_name: AERmon.ztp
     sources: [model_var: TROP_Z]
     table: atmos
     units: m

--- a/data/noresm_to_cmip7.yaml
+++ b/data/noresm_to_cmip7.yaml
@@ -1755,7 +1755,6 @@ variables:
   ta_tavg-p39-hy-air:
     description: Air Temperature
     dims: [time, plev, lat]
-    formula: zonal_mean_on_pressure_grid("T")
     levels: {name: plev39, units: Pa}
     sources: [model_var: T]
     table: atmos
@@ -1956,7 +1955,6 @@ variables:
   ua_tavg-p39-hy-air:
     description: Zonal wind (positive in a eastward direction).
     dims: [time, plev, lat]
-    formula: zonal_mean_on_pressure_grid("U")
     levels: {name: plev39, units: Pa}
     sources: [model_var: U]
     table: atmos
@@ -1982,7 +1980,6 @@ variables:
   va_tavg-p39-hy-air:
     description: Meridional wind (positive in a northward direction).
     dims: [time, plev, lat]
-    formula: zonal_mean_on_pressure_grid("V")
     levels: {name: plev39, units: Pa}
     sources: [model_var: V]
     table: atmos
@@ -2128,7 +2125,6 @@ variables:
       It is numerically similar to the altitude (or geometric height) and not to the
       quantity with standard name height, which is relative to the surface.
     dims: [time, plev, lat]
-    formula: zonal_mean_on_pressure_grid("Z3")
     levels: {name: plev39, units: Pa}
     sources: [model_var: Z3]
     table: atmos

--- a/data/noresm_to_cmip7.yaml
+++ b/data/noresm_to_cmip7.yaml
@@ -833,6 +833,7 @@ variables:
   hfls_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: LHFLX]
     table: atmos
     units: W m-2
@@ -840,6 +841,7 @@ variables:
   hfss_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: SHFLX]
     table: atmos
     units: W m-2
@@ -1450,6 +1452,7 @@ variables:
   rlds_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FLDS]
     table: atmos
     units: W m-2
@@ -1464,6 +1467,7 @@ variables:
   rls_tavg-u-hxy-u:
     description: Net longwave surface radiation
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FLNS]
     table: atmos
     units: W m-2
@@ -1499,6 +1503,7 @@ variables:
   rlut_tavg-u-hxy-u:
     description: at the top of the atmosphere (to be compared with satellite measurements)
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FSNTOA, model_var: FSNT, model_var: FLNT]
     table: atmos
     units: W m-2
@@ -1506,6 +1511,7 @@ variables:
   rlutcs_tavg-u-hxy-u:
     description: Upwelling clear-sky longwave radiation at top of atmosphere
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FSNTOAC, model_var: FSNTC, model_var: FLNTC]
     table: atmos
     units: W m-2
@@ -1544,6 +1550,7 @@ variables:
   rsds_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FSDS]
     table: atmos
     units: W m-2
@@ -1551,6 +1558,7 @@ variables:
   rsdscs_tavg-u-hxy-u:
     description: Surface solar irradiance clear sky for UV calculations
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FSDSC]
     table: atmos
     units: W m-2
@@ -1567,6 +1575,7 @@ variables:
   rsdt_tavg-u-hxy-u:
     description: at the top of the atmosphere
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FSNTOA, model_var: FSUTOA]
     table: atmos
     units: W m-2
@@ -1574,6 +1583,7 @@ variables:
   rss_tavg-u-hxy-u:
     description: Net downward shortwave radiation at the surface
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FSNS]
     table: atmos
     units: W m-2
@@ -1620,6 +1630,7 @@ variables:
   rsuscs_tavg-u-hxy-u:
     description: Surface Upwelling Clear-sky Shortwave Radiation
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FSDSC, model_var: FSNSC]
     table: atmos
     units: W m-2
@@ -1627,6 +1638,7 @@ variables:
   rsut_tavg-u-hxy-u:
     description: at the top of the atmosphere
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: FSUTOA]
     table: atmos
     units: W m-2
@@ -1634,6 +1646,7 @@ variables:
   rsutcs_tavg-u-hxy-u:
     description: Calculated in the absence of clouds.
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: SOLIN, model_var: FSNTOAC]
     table: atmos
     units: W m-2
@@ -1644,6 +1657,7 @@ variables:
       the net downward radiative flux at the top of the atmosphere.
     dims: [lon, lat, time]
     formula: FSNT-FLNT
+    positive: down
     sources: [model_var: FSNT, model_var: FLNT]
     table: atmos
     units: W m-2
@@ -1794,6 +1808,7 @@ variables:
   tauu_tavg-u-hxy-u:
     description: Downward eastward wind stress at the surface
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: TAUX]
     table: atmos
     units: Pa
@@ -1801,6 +1816,7 @@ variables:
   tauv_tavg-u-hxy-u:
     description: Downward northward wind stress at the surface
     dims: [lon, lat, time]
+    positive: down
     sources: [model_var: TAUY]
     table: atmos
     units: Pa

--- a/data/noresm_to_cmip7.yaml
+++ b/data/noresm_to_cmip7.yaml
@@ -9,18 +9,16 @@ variables:
     description: Time-means are weighted by the ISCCP Total Cloud Fraction - see  https://www.cfmip.org/tools-and-data/cosp.
       Values will be missing where there are no clouds or no sunlight.
     dims: [lon, lat, time]
-    sources: [{freq: day, model_var: MEANCLDALB_ISCCP}, model_var: CLDTOT_ISCCP]
+    sources: [model_var: MEANCLDALB_ISCCP, model_var: CLDTOT_ISCCP]
     table: atmos
     units: '1'
-    variants: [{formula: MEANCLDALB_ISCCP/CLDTOT_ISCCP, long_name: CFday.albisccp},
-      {formula: MEANCLDALB_ISCCP/CLDTOT_ISCCP, long_name: CFmon.albisccp}]
 
   aod550volso4_tavg-u-hxy-u:
     description: This is the monthly averaged aerosol optical thickness at 550 nm
       due to stratospheric volcanic sulphate aerosols
     dims: [lon, lat, time, lambda550nm]
     long_name: Amon.aod550volso4
-    sources: [{freq: mon, model_var: AODVVOLC}]
+    sources: [model_var: AODVVOLC]
     table: atmos
     units: '1.00E-09'
 
@@ -31,24 +29,22 @@ variables:
       of vertical fluxes of energy at the surface and top of the atmosphere).
     dims: [lon, lat]
     long_name: fx.areacella
-    sources: [{freq: fx, model_var: area}]
+    sources: [model_var: area]
     table: atmos
     units: m2
 
   baresoilFrac_tavg-u-hxy-u:
     description: Percentage of entire grid cell  that is covered by bare soil.
     dims: [lon, lat, time, typebare]
-    sources: [{freq: yr, model_var: AREA_PLANTS}, model_var: FATES_FRACTION]
+    sources: [model_var: AREA_PLANTS, model_var: FATES_FRACTION]
     table: land
     units: '%'
-    variants: [{formula: (1-AREA_PLANTS)*FATES_FRACTION, long_name: Eyr.baresoilFrac},
-      {formula: (1-FATES_AREA_PLANTS)*FATES_FRACTION, long_name: Lmon.baresoilFrac}]
 
   bldep_tavg-u-hxy-u:
     description: Boundary layer depth
     dims: [lon, lat, time]
     long_name: AERmon.bldep
-    sources: [{freq: mon, model_var: PBLH}]
+    sources: [model_var: PBLH]
     table: atmos
     units: m
 
@@ -58,7 +54,7 @@ variables:
     dims: [lon, lat, time, typeburnt]
     formula: (FATES_BURNFRAC *3600*24*30*100)*FATES_FRACTION
     long_name: Lmon.burntFractionAll
-    sources: [{freq: mon, model_var: FATES_BURNFRAC}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_BURNFRAC, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
@@ -68,8 +64,7 @@ variables:
     dims: [lon, lat, time, typec3pft]
     formula: (FATES_AREA_PLANTS-sumoverpft(FATES_CROWNAREA_PF, pftlist=[14], dim='fates_levpft'))*FATES_FRACTION
     long_name: Lmon.c3PftFrac
-    sources: [{freq: mon, model_var: FATES_AREA_PLANTS}, model_var: FATES_CROWNAREA_PF,
-      model_var: FATES_FRACTION]
+    sources: [model_var: FATES_AREA_PLANTS, model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
@@ -79,7 +74,7 @@ variables:
     dims: [lon, lat, time, typec4pft]
     formula: sumoverpft(FATES_CROWNAREA_PF, pftlist=[14], dim='fates_levpft')*FATES_FRACTION
     long_name: Lmon.c4PftFrac
-    sources: [{freq: mon, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
@@ -88,7 +83,7 @@ variables:
       value averaged over the land fraction.
     dims: [lon, lat, time]
     long_name: Emon.cLand
-    sources: [{freq: mon, model_var: TOTECOSYSC}]
+    sources: [model_var: TOTECOSYSC]
     table: land
     units: kg m-2
 
@@ -96,7 +91,7 @@ variables:
     description: Carbon mass per unit area in leaves.
     dims: [lon, lat, time]
     long_name: Lmon.cLeaf
-    sources: [{freq: mon, model_var: FATES_LEAFC}]
+    sources: [model_var: FATES_LEAFC]
     table: land
     units: kg m-2
 
@@ -106,7 +101,7 @@ variables:
       The precise distinction between "fine" and "coarse" is model dependent.'
     dims: [lon, lat, time]
     long_name: Emon.cLitterCwd
-    sources: [{freq: mon, model_var: FATES_LITTER_BG_CWD_EL}]
+    sources: [model_var: FATES_LITTER_BG_CWD_EL]
     table: land
     units: kg m-2
 
@@ -115,7 +110,7 @@ variables:
     dims: [lon, lat, time]
     formula: (FATES_LITTER_BG_FINE_EL + FATES_LITTER_BG_CWD_EL)*FATES_FRACTION
     long_name: Emon.cLitterSubSurf
-    sources: [{freq: mon, model_var: FATES_LITTER_BG_FINE_EL}, model_var: FATES_LITTER_BG_CWD_EL,
+    sources: [model_var: FATES_LITTER_BG_FINE_EL, model_var: FATES_LITTER_BG_CWD_EL,
       model_var: FATES_FRACTION]
     table: land
     units: kg m-2
@@ -125,7 +120,7 @@ variables:
       litterfall
     dims: [lon, lat, time]
     long_name: Emon.cLitterSurf
-    sources: [{freq: mon, model_var: FATES_LITTER_AG_FINE_EL}]
+    sources: [model_var: FATES_LITTER_AG_FINE_EL]
     table: land
     units: kg m-2
 
@@ -133,7 +128,7 @@ variables:
     description: E.g. fruits, seeds, etc.
     dims: [lon, lat, time]
     long_name: Emon.cOther
-    sources: [{freq: mon, model_var: FATES_SEED_BANK}]
+    sources: [model_var: FATES_SEED_BANK]
     table: land
     units: kg m-2
 
@@ -143,7 +138,7 @@ variables:
     dims: [lon, lat, time]
     formula: CROPPROD1C+TOT_WOODPRODC
     long_name: Lmon.cProduct
-    sources: [{freq: mon, model_var: CROPPROD1C}, model_var: TOT_WOODPRODC]
+    sources: [model_var: CROPPROD1C, model_var: TOT_WOODPRODC]
     table: land
     units: kg m-2
 
@@ -152,8 +147,7 @@ variables:
       If models also have vertical discretisation these should be aggregated
     dims: [lon, lat, soilpools, time]
     long_name: Emon.cSoilPools
-    sources: [{freq: mon, model_var: SOIL1C}, model_var: SOIL2C, model_var: SOIL3C,
-      model_var: SOIL4C]
+    sources: [model_var: SOIL1C, model_var: SOIL2C, model_var: SOIL3C, model_var: SOIL4C]
     table: land
     units: kg m-2
 
@@ -162,7 +156,7 @@ variables:
       value averaged over the land fraction.
     dims: [lon, lat, time, sdepth100cm]
     long_name: Emon.cSoilAbove1m
-    sources: [{freq: mon, model_var: TOTSOMC_1m}]
+    sources: [model_var: TOTSOMC_1m]
     table: land
     units: kg m-2
 
@@ -172,7 +166,7 @@ variables:
     dims: [lon, lat, sdepth, time]
     formula: SOIL1C_vr+SOIL2C_vr+SOIL3C_vr+SOIL4C_vr
     long_name: Emon.cSoilLevels
-    sources: [{freq: mon, model_var: SOIL1C_vr}, model_var: SOIL2C_vr, model_var: SOIL3C_vr,
+    sources: [model_var: SOIL1C_vr, model_var: SOIL2C_vr, model_var: SOIL3C_vr,
       model_var: SOIL4C_vr]
     table: land
     units: kg m-2
@@ -181,7 +175,7 @@ variables:
     description: Carbon mass in the full depth of the soil model.
     dims: [lon, lat, time]
     long_name: Emon.cSoil
-    sources: [{freq: mon, model_var: TOTSOMC}]
+    sources: [model_var: TOTSOMC]
     table: land
     units: kg m-2
 
@@ -189,7 +183,7 @@ variables:
     description: including sapwood and hardwood.
     dims: [lon, lat, time]
     long_name: Emon.cStem
-    sources: [{freq: mon, model_var: FATES_STRUCTC}]
+    sources: [model_var: FATES_STRUCTC]
     table: land
     units: kg m-2
 
@@ -198,7 +192,7 @@ variables:
     dims: [lon, lat, time]
     formula: FATES_VEGC *FATES_FRACTION
     long_name: Lmon.cVeg
-    sources: [{freq: mon, model_var: FATES_VEGC}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_VEGC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
 
@@ -209,7 +203,7 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_VEGC_PF, pftlist=[12, 13, 14], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.cVegGrass
-    sources: [{freq: mon, model_var: FATES_VEGC_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_VEGC_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
 
@@ -220,7 +214,7 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_VEGC_PF, pftlist=[7, 8, 9, 10, 11], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.cVegShrub
-    sources: [{freq: mon, model_var: FATES_VEGC_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_VEGC_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
 
@@ -231,7 +225,7 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_VEGC_PF, pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.cVegTree
-    sources: [{freq: mon, model_var: FATES_VEGC_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_VEGC_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
 
@@ -239,7 +233,7 @@ variables:
     description: CloudSat Radar Reflectivity
     dims: [lon, lat, alt40, dbze, time]
     long_name: Emon.cfadDbze94
-    sources: [{freq: mon, model_var: CFAD_DBZE94_CS}]
+    sources: [model_var: CFAD_DBZE94_CS]
     table: atmos
     units: '1'
 
@@ -247,7 +241,7 @@ variables:
     description: CALIPSO Scattering Ratio
     dims: [lon, lat, alt40, scatratio, time]
     long_name: Emon.cfadLidarsr532
-    sources: [{freq: mon, model_var: CFAD_SR532_CAL}]
+    sources: [model_var: CFAD_SR532_CAL]
     table: atmos
     units: '1'
 
@@ -256,40 +250,36 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    sources: [{freq: mon, model_var: CLOUD}]
+    sources: [model_var: CLOUD]
     table: atmos
     units: '%'
-    variants: [{long_name: Amon.cl}, {long_name: CFday.cl}]
 
   clcalipso_tavg-220hPa-hxy-air:
     description: Percentage cloud cover in layer centred on 220hPa
     dims: [lon, lat, time, p220]
-    sources: [{freq: day, model_var: CLDGHG_CAL}]
+    sources: [model_var: CLDGHG_CAL]
     table: atmos
     units: '%'
-    variants: [{long_name: CFday.clhcalipso}, {long_name: CFmon.clhcalipso}]
 
   clcalipso_tavg-560hPa-hxy-air:
     description: Percentage cloud cover in layer centred on 560hPa
     dims: [lon, lat, time, p560]
-    sources: [{freq: day, model_var: CLDMED_CAL}]
+    sources: [model_var: CLDMED_CAL]
     table: atmos
     units: '%'
-    variants: [{long_name: CFday.clmcalipso}, {long_name: CFmon.clmcalipso}]
 
   clcalipso_tavg-840hPa-hxy-air:
     description: Percentage cloud cover in layer centred on 840hPa
     dims: [lon, lat, time, p840]
-    sources: [{freq: day, model_var: CLDLOW_CAL}]
+    sources: [model_var: CLDLOW_CAL]
     table: atmos
     units: '%'
-    variants: [{long_name: CFday.cllcalipso}, {long_name: CFmon.cllcalipso}]
 
   clcalipsoice_tavg-h40-hxy-air:
     description: CALIPSO Ice Cloud Fraction
     dims: [lon, lat, alt40, time]
     long_name: Emon.clcalipsoice
-    sources: [{freq: mon, model_var: CLDTOT_CAL_ICE}]
+    sources: [model_var: CLDTOT_CAL_ICE]
     table: atmos
     units: '%'
 
@@ -297,7 +287,7 @@ variables:
     description: CALIPSO Liquid Cloud Fraction
     dims: [lon, lat, alt40, time]
     long_name: Emon.clcalipsoliq
-    sources: [{freq: mon, model_var: CLDTOT_CAL_LIQ}]
+    sources: [model_var: CLDTOT_CAL_LIQ]
     table: atmos
     units: '%'
 
@@ -310,26 +300,24 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    sources: [{freq: mon, model_var: CLDICE}]
+    sources: [model_var: CLDICE]
     table: atmos
     units: kg kg-1
-    variants: [{long_name: Amon.cli}, {long_name: CFday.cli}]
 
   climodis_tavg-u-hxy-u:
     description: MODIS Ice Cloud Fraction
     dims: [lon, lat, time]
     long_name: Emon.climodis
-    sources: [{freq: mon, model_var: CLIMODIS}]
+    sources: [model_var: CLIMODIS]
     table: atmos
     units: '%'
 
   clisccp_tavg-p7c-hxy-air:
     description: Percentage cloud cover in optical depth categories.
     dims: [lon, lat, plev7c, tau, time]
-    sources: [{freq: day, model_var: FISCCP1_COSP}]
+    sources: [model_var: FISCCP1_COSP]
     table: atmos
     units: '%'
-    variants: [{long_name: CFday.clisccp}, {long_name: CFmon.clisccp}]
 
   clivi_tavg-u-hxy-u:
     description: mass of ice water in the column divided by the area of the column
@@ -337,16 +325,15 @@ variables:
       frozen hydrometeors ONLY if the precipitating hydrometeor affects the calculation
       of radiative transfer in model.
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: TGCLDIWP}]
+    sources: [model_var: TGCLDIWP]
     table: atmos
     units: kg m-2
-    variants: [{long_name: Amon.clivi}, {long_name: CFday.clivi}, {long_name: E3hr.clivi}]
 
   clt_tavg-u-hxy-lnd:
     description: Total cloud fraction
     dims: [lon, lat, time]
     long_name: Eday.clt
-    sources: [{freq: day, model_var: CLDTOT}]
+    sources: [model_var: CLDTOT]
     table: atmos
     units: '%'
 
@@ -355,18 +342,16 @@ variables:
       top of the atmosphere. Include both large-scale and convective cloud.  This
       is a 3-hour mean.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: CLDTOT}]
+    sources: [model_var: CLDTOT]
     table: atmos
     units: '%'
-    variants: [{long_name: 3hr.clt}, {formula: CLDTOT*100, long_name: Amon.clt}, {
-        long_name: day.clt}]
 
   cltc_tavg-u-hxy-u:
     description: Convective cloud fraction
     dims: [lon, lat, time]
     formula: CONCLD*100
     long_name: AERmon.cltc
-    sources: [{freq: mon, model_var: CONCLD}]
+    sources: [model_var: CONCLD]
     table: atmos
     units: '%'
 
@@ -376,10 +361,9 @@ variables:
       Satellite Observation (CALIPSO) instrument. Includes both large-scale and convective
       cloud.
     dims: [lon, lat, time]
-    sources: [{freq: day, model_var: CLDTOT_CAL}]
+    sources: [model_var: CLDTOT_CAL]
     table: atmos
     units: '%'
-    variants: [{long_name: CFday.cltcalipso}, {long_name: CFmon.cltcalipso}]
 
   cltisccp_tavg-u-hxy-u:
     description: Total cloud area fraction (reported as a percentage) for the whole
@@ -387,16 +371,15 @@ variables:
       Project (ISCCP) analysis. Includes both large-scale and convective cloud.  (MODIS).
       Includes both large-scale and convective cloud.
     dims: [lon, lat, time]
-    sources: [{freq: day, model_var: CLDTOT_ISCCP}]
+    sources: [model_var: CLDTOT_ISCCP]
     table: atmos
     units: '%'
-    variants: [{long_name: CFday.cltisccp}, {long_name: CFmon.cltisccp}]
 
   cltmodis_tavg-u-hxy-u:
     description: Percentage of total cloud cover as seen by the MODIS instrument simulator.
     dims: [lon, lat, time]
     long_name: Emon.cltmodis
-    sources: [{freq: mon, model_var: CLTMODIS}]
+    sources: [model_var: CLTMODIS]
     table: atmos
     units: '%'
 
@@ -409,16 +392,15 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    sources: [{freq: mon, model_var: CLDLIQ}]
+    sources: [model_var: CLDLIQ]
     table: atmos
     units: kg kg-1
-    variants: [{long_name: Amon.clw}, {long_name: CFday.clw}]
 
   clwmodis_tavg-u-hxy-u:
     description: MODIS Liquid Cloud Fraction
     dims: [lon, lat, time]
     long_name: Emon.clwmodis
-    sources: [{freq: mon, model_var: CLWMODIS}]
+    sources: [model_var: CLWMODIS]
     table: atmos
     units: '%'
 
@@ -429,7 +411,7 @@ variables:
       the calculation of radiative transfer in model.
     dims: [lon, lat, time]
     long_name: Amon.clwvi
-    sources: [{freq: mon, model_var: TGCLDCWP}]
+    sources: [model_var: TGCLDCWP]
     table: atmos
     units: kg m-2
 
@@ -437,7 +419,7 @@ variables:
     description: Canopy covered fraction
     dims: [lon, lat, time]
     long_name: Emon.cnc
-    sources: [{freq: mon, model_var: FATES_AREA_PLANTS}]
+    sources: [model_var: FATES_AREA_PLANTS]
     table: land
     units: '%'
 
@@ -448,7 +430,7 @@ variables:
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
     long_name: AERmon.co2
-    sources: [{freq: mon, model_var: CO2}]
+    sources: [model_var: CO2]
     table: atmos
     units: mol mol-1
 
@@ -457,7 +439,7 @@ variables:
       where X is a material constituent of Y.
     dims: [lon, lat, plev19, time]
     long_name: Amon.co2
-    sources: [{freq: mon, model_var: CO2}]
+    sources: [model_var: CO2]
     table: atmos
     units: mol mol-1
 
@@ -466,19 +448,16 @@ variables:
     dims: [time]
     formula: co2vmr*1.5172413793
     long_name: Amon.co2mass
-    sources: [{freq: mon, model_var: co2vmr}]
+    sources: [model_var: co2vmr]
     table: atmos
     units: kg
 
   cropFrac_tavg-u-hxy-u:
     description: Percentage of entire grid cell  that is covered by crop.
     dims: [lon, lat, time, typecrop]
-    sources: [{freq: yr, model_var: FATES_PATCHAREA_LU}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_PATCHAREA_LU, model_var: FATES_FRACTION]
     table: land
     units: '%'
-    variants: [{formula: '(sumoverpft(FATES_PATCHAREA_LU, pftlist=[5], dim=''fates_levlanduse''))*FATES_FRACTION',
-        long_name: Eyr.cropFrac}, {formula: '(sumoverpft(FATES_PATCHAREA_LU, pftlist=[5],
-          dim=''fates_levlanduse''))*FATES_FRACTION', long_name: Lmon.cropFrac}]
 
   depthsl_ti-u-hxy-u:
     description: Total (cumulative) thickness of all soil layers. This is the sum
@@ -486,7 +465,7 @@ variables:
     dims: [lon, lat]
     formula: sum(DZSOI)
     long_name: fx.depthsl
-    sources: [{freq: fx, model_var: DZSOI}]
+    sources: [model_var: DZSOI]
     table: land
     units: m
 
@@ -495,7 +474,7 @@ variables:
       the surface where there is snow on land
     dims: [lon, lat, time]
     long_name: Eday.esn
-    sources: [{freq: day, model_var: QSNOEVAP}]
+    sources: [model_var: QSNOEVAP]
     table: land
     units: kg m-2 s-1
 
@@ -506,7 +485,7 @@ variables:
     dims: [lon, lat, time]
     formula: QVEGT+QVEGE+QSOIL
     long_name: Eday.evspsbl
-    sources: [{freq: day, model_var: QVEGT}, model_var: QVEGE, model_var: QSOIL]
+    sources: [model_var: QVEGT, model_var: QVEGE, model_var: QSOIL]
     table: atmos
     units: kg m-2 s-1
 
@@ -515,7 +494,7 @@ variables:
       both liquid and solid phases to vapor (from underlying surface and vegetation)
     dims: [lon, lat, time]
     long_name: Amon.evspsbl
-    sources: [{freq: mon, model_var: QFLX}]
+    sources: [model_var: QFLX]
     table: atmos
     units: kg m-2 s-1
 
@@ -523,40 +502,38 @@ variables:
     description: includes sublimation.
     dims: [lon, lat, time]
     long_name: Lmon.evspsblsoi
-    sources: [{freq: mon, model_var: QSOIL}]
+    sources: [model_var: QSOIL]
     table: land
     units: kg m-2 s-1
 
   evspsblsoi_tavg-u-hxy-u:
     description: Water evaporation from soil
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: QSOIL}]
+    sources: [model_var: QSOIL]
     table: land
     units: kg m-2 s-1
-    variants: [{long_name: 3hr.evspsblsoi}, {long_name: Eday.evspsblsoi}]
 
   evspsblveg_tavg-u-hxy-lnd:
     description: the canopy evaporation+sublimation (if present in model).
     dims: [lon, lat, time]
     long_name: Lmon.evspsblveg
-    sources: [{freq: mon, model_var: QVEGE}]
+    sources: [model_var: QVEGE]
     table: land
     units: kg m-2 s-1
 
   evspsblveg_tavg-u-hxy-u:
     description: Evaporation from canopy
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: QVEGE}]
+    sources: [model_var: QVEGE]
     table: land
     units: kg m-2 s-1
-    variants: [{long_name: 3hr.evspsblveg}, {long_name: Eday.evspsblveg}]
 
   fBNF_tavg-u-hxy-lnd:
     description: The fixation (uptake of nitrogen gas directly from the atmosphere)
       of nitrogen due to biological processes.
     dims: [lon, lat, time]
     long_name: Emon.fBNF
-    sources: [{freq: mon, model_var: NFIX_TO_SMINN}]
+    sources: [model_var: NFIX_TO_SMINN]
     table: land
     units: kg m-2 s-1
 
@@ -566,7 +543,7 @@ variables:
     dims: [lon, lat, time]
     formula: SOM_C_LEACHED *1000
     long_name: Emon.fCLandToOcean
-    sources: [{freq: mon, model_var: SOM_C_LEACHED}]
+    sources: [model_var: SOM_C_LEACHED]
     table: land
     units: kg m-2 s-1
 
@@ -578,7 +555,7 @@ variables:
     dims: [lon, lat, time]
     formula: DWT_CROPPROD1C_GAIN+DWT_WOODPRODC_GAIN
     long_name: Emon.fDeforestToProduct
-    sources: [{freq: mon, model_var: DWT_CROPPROD1C_GAIN}, model_var: DWT_WOODPRODC_GAIN]
+    sources: [model_var: DWT_CROPPROD1C_GAIN, model_var: DWT_WOODPRODC_GAIN]
     table: land
     units: kg m-2 s-1
 
@@ -587,7 +564,7 @@ variables:
       change. Only total fire emissions can be compared to observations.
     dims: [lon, lat, time]
     long_name: Emon.fFireAll
-    sources: [{freq: mon, model_var: FATES_FIRE_CLOSS}]
+    sources: [model_var: FATES_FIRE_CLOSS]
     table: land
     units: kg m-2 s-1
 
@@ -595,7 +572,7 @@ variables:
     description: CO2 emissions from natural fires
     dims: [lon, lat, time]
     long_name: Emon.fFireNat
-    sources: [{freq: mon, model_var: FATES_FIRE_CLOSS}]
+    sources: [model_var: FATES_FIRE_CLOSS]
     table: land
     units: kg m-2 s-1
 
@@ -606,7 +583,7 @@ variables:
       from Land Use Change).
     dims: [lon, lat, time]
     long_name: Lmon.fFire
-    sources: [{freq: mon, model_var: FATES_FIRE_CLOSS}]
+    sources: [model_var: FATES_FIRE_CLOSS]
     table: land
     units: kg m-2 s-1
 
@@ -615,7 +592,7 @@ variables:
       material in or above the soil).
     dims: [lon, lat, time]
     long_name: Lmon.fLitterSoil
-    sources: [{freq: mon, model_var: FATES_LITTER_OUT_EL}]
+    sources: [model_var: FATES_LITTER_OUT_EL]
     table: land
     units: kg m-2 s-1
 
@@ -623,7 +600,7 @@ variables:
     description: Net Carbon Mass Flux into Atmosphere due to Land Use Change
     dims: [lon, lat, time]
     long_name: Emon.fLuc
-    sources: [{freq: mon, model_var: LAND_USE_FLUX}]
+    sources: [model_var: LAND_USE_FLUX]
     table: land
     units: kg m-2 s-1
 
@@ -634,7 +611,7 @@ variables:
       and  emissions form anthropogenic pools into atmosphere
     dims: [lon, lat, landuse, time]
     long_name: Emon.fLulccAtmLut
-    sources: [{freq: mon, model_var: DWT_CONV_CFLUX}]
+    sources: [model_var: DWT_CONV_CFLUX]
     table: land
     units: kg m-2 s-1
 
@@ -645,7 +622,7 @@ variables:
     dims: [lon, lat, time]
     formula: F_N2O_DENIT+F_N2O_NIT
     long_name: Emon.fN2O
-    sources: [{freq: mon, model_var: F_N2O_DENIT}, model_var: F_N2O_NIT]
+    sources: [model_var: F_N2O_DENIT, model_var: F_N2O_NIT]
     table: land
     units: kg m-2 s-1
 
@@ -654,7 +631,7 @@ variables:
       finds its way into ocean should be reported here.
     dims: [lon, lat, time]
     long_name: Emon.fNLandToOcean
-    sources: [{freq: mon, model_var: SMIN_NO3_LEACHED}]
+    sources: [model_var: SMIN_NO3_LEACHED]
     table: land
     units: kg m-2 s-1
 
@@ -672,7 +649,7 @@ variables:
     dims: [lon, lat, time]
     formula: SMIN_NO3_LEACHED+SMIN_NO3_RUNOFF
     long_name: Emon.fNOx
-    sources: [{freq: mon, model_var: SMIN_NO3_LEACHED}, model_var: SMIN_NO3_RUNOFF]
+    sources: [model_var: SMIN_NO3_LEACHED, model_var: SMIN_NO3_RUNOFF]
     table: land
     units: kg m-2 s-1
 
@@ -684,7 +661,7 @@ variables:
     dims: [lon, lat, time]
     formula: DWT_WOODPRODN_GAIN + DWT_CROPPROD1N_GAIN
     long_name: Emon.fNProduct
-    sources: [{freq: mon, model_var: DWT_WOODPRODN_GAIN}, model_var: DWT_CROPPROD1N_GAIN]
+    sources: [model_var: DWT_WOODPRODN_GAIN, model_var: DWT_CROPPROD1N_GAIN]
     table: land
     units: kg m-2 s-1
 
@@ -692,7 +669,7 @@ variables:
     description: Surface deposition rate of nitrogen.
     dims: [lon, lat, time]
     long_name: Emon.fNdep
-    sources: [{freq: mon, model_var: NDEP_TO_SMINN}]
+    sources: [model_var: NDEP_TO_SMINN]
     table: land
     units: kg m-2 s-1
 
@@ -700,7 +677,7 @@ variables:
     description: Flux of Nitrogen from the land into the atmosphere due to fire
     dims: [lon, lat, time]
     long_name: Emon.fNgasFire
-    sources: [{freq: mon, model_var: COL_FIRE_NLOSS}]
+    sources: [model_var: COL_FIRE_NLOSS]
     table: land
     units: kg m-2 s-1
 
@@ -710,7 +687,7 @@ variables:
     dims: [lon, lat, time]
     formula: DENIT+F_N2O_NIT
     long_name: Emon.fNgasNonFire
-    sources: [{freq: mon, model_var: DENIT}, model_var: F_N2O_NIT]
+    sources: [model_var: DENIT, model_var: F_N2O_NIT]
     table: land
     units: kg m-2 s-1
 
@@ -719,7 +696,7 @@ variables:
     dims: [lon, lat, time]
     formula: DENIT+F_N2O_NIT+COL_FIRE_NLOSS
     long_name: Emon.fNgas
-    sources: [{freq: mon, model_var: DENIT}, model_var: F_N2O_NIT, model_var: COL_FIRE_NLOSS]
+    sources: [model_var: DENIT, model_var: F_N2O_NIT, model_var: COL_FIRE_NLOSS]
     table: land
     units: kg m-2 s-1
 
@@ -734,7 +711,7 @@ variables:
     dims: [lon, lat, time]
     formula: SMIN_NO3_LEACHED+ SMIN_NO3_RUNOFF
     long_name: Emon.fNleach
-    sources: [{freq: mon, model_var: SMIN_NO3_LEACHED}, model_var: SMIN_NO3_RUNOFF]
+    sources: [model_var: SMIN_NO3_LEACHED, model_var: SMIN_NO3_RUNOFF]
     table: land
     units: kg m-2 s-1
 
@@ -743,7 +720,7 @@ variables:
     dims: [lon, lat, time]
     formula: DENIT+ F_N2O_NIT+ SMIN_NO3_LEACHED + SMIN_NO3_RUNOFF
     long_name: Emon.fNloss
-    sources: [{freq: mon, model_var: DENIT}, model_var: F_N2O_NIT, model_var: SMIN_NO3_LEACHED,
+    sources: [model_var: DENIT, model_var: F_N2O_NIT, model_var: SMIN_NO3_LEACHED,
       model_var: SMIN_NO3_RUNOFF]
     table: land
     units: kg m-2 s-1
@@ -756,7 +733,7 @@ variables:
       by micro-organisms under certain conditions, making it unavailable for plants.
     dims: [lon, lat, time]
     long_name: Emon.fNnetmin
-    sources: [{freq: mon, model_var: NET_NMIN}]
+    sources: [model_var: NET_NMIN]
     table: land
     units: kg m-2 s-1
 
@@ -770,7 +747,7 @@ variables:
     dims: [lon, lat, time]
     formula: TOT_WOODPRODC_LOSS+CROPPROD1C_LOSS
     long_name: Emon.fProductDecomp
-    sources: [{freq: mon, model_var: TOT_WOODPRODC_LOSS}, model_var: CROPPROD1C_LOSS]
+    sources: [model_var: TOT_WOODPRODC_LOSS, model_var: CROPPROD1C_LOSS]
     table: land
     units: kg m-2 s-1
 
@@ -779,7 +756,7 @@ variables:
       turnover times, since total fire flux draws from both sources
     dims: [lon, lat, time]
     long_name: Emon.fVegFire
-    sources: [{freq: mon, model_var: FATES_FIRE_CLOSS}]
+    sources: [model_var: FATES_FIRE_CLOSS]
     table: land
     units: kg m-2 s-1
 
@@ -789,7 +766,7 @@ variables:
     dims: [lon, lat, time]
     formula: (FATES_MORTALITY_CFLUX_CANOPY+FATES_MORTALITY_CFLUX_USTORY)*FATES_FRACTION
     long_name: Emon.fVegLitterMortality
-    sources: [{freq: mon, model_var: FATES_MORTALITY_CFLUX_CANOPY}, model_var: FATES_MORTALITY_CFLUX_USTORY,
+    sources: [model_var: FATES_MORTALITY_CFLUX_CANOPY, model_var: FATES_MORTALITY_CFLUX_USTORY,
       model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -800,7 +777,7 @@ variables:
     dims: [lon, lat, time]
     formula: (FATES_LITTER_IN_EL-FATES_MORTALITY_CFLUX_CANOPY+FATES_MORTALITY_CFLUX_USTORY)*FATES_FRACTION
     long_name: Emon.fVegLitterSenescence
-    sources: [{freq: mon, model_var: FATES_LITTER_IN_EL}, model_var: FATES_MORTALITY_CFLUX_CANOPY,
+    sources: [model_var: FATES_LITTER_IN_EL, model_var: FATES_MORTALITY_CFLUX_CANOPY,
       model_var: FATES_MORTALITY_CFLUX_USTORY, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -815,7 +792,7 @@ variables:
       and mass_flux_of_carbon_into_litter_from_vegetation_due_to_senescence is mass_flux_of_carbon_into_litter_from_vegetation.
     dims: [lon, lat, time]
     long_name: Lmon.fVegLitter
-    sources: [{freq: mon, model_var: FATES_LITTER_IN_EL}]
+    sources: [model_var: FATES_LITTER_IN_EL]
     table: land
     units: kg m-2 s-1
 
@@ -825,7 +802,7 @@ variables:
     dims: [lon, lat, time]
     formula: (FATES_MORTALITY_CFLUX_CANOPY+FATES_MORTALITY_CFLUX_USTORY)*FATES_FRACTION
     long_name: Emon.fVegSoilMortality
-    sources: [{freq: mon, model_var: FATES_MORTALITY_CFLUX_CANOPY}, model_var: FATES_MORTALITY_CFLUX_USTORY,
+    sources: [model_var: FATES_MORTALITY_CFLUX_CANOPY, model_var: FATES_MORTALITY_CFLUX_USTORY,
       model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
@@ -834,7 +811,7 @@ variables:
       should be reported as a percentage of atmospheric grid cell
     dims: [lon, lat, landuse, time]
     long_name: Eyr.fracInLut
-    sources: [{freq: yr, model_var: FATES_TRANSITION_MATRIX_LULU}]
+    sources: [model_var: FATES_TRANSITION_MATRIX_LULU]
     table: land
     units: '%'
   fracOutLut_tsum-u-hxy-lnd:
@@ -842,7 +819,7 @@ variables:
       should be reported as percentage of atmospheric grid cell
     dims: [lon, lat, landuse, time]
     long_name: Eyr.fracOutLut
-    sources: [{freq: yr, model_var: FATES_TRANSITION_MATRIX_LULU}]
+    sources: [model_var: FATES_TRANSITION_MATRIX_LULU]
     table: land
     units: '%'
 
@@ -854,7 +831,7 @@ variables:
       Reported on land-use tiles.
     dims: [lon, lat, landuse, time]
     long_name: Emon.gppLut
-    sources: [{freq: mon, model_var: FATES_GPP_LU}]
+    sources: [model_var: FATES_GPP_LU]
     table: land
     units: kg m-2 s-1
 
@@ -865,7 +842,7 @@ variables:
       this biomass and the difference is referred to as the net primary production.
     dims: [lon, lat, time]
     long_name: Lmon.gpp
-    sources: [{freq: mon, model_var: FATES_GPP}]
+    sources: [model_var: FATES_GPP]
     table: land
     units: kg m-2 s-1
 
@@ -874,7 +851,7 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[12, 13, 14], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.gppGrass
-    sources: [{freq: mon, model_var: FATES_GPP_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_GPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -883,7 +860,7 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[7, 8, 9, 10, 11], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.gppShrub
-    sources: [{freq: mon, model_var: FATES_GPP_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_GPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -892,7 +869,7 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.gppTree
-    sources: [{freq: mon, model_var: FATES_GPP_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_GPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -901,7 +878,7 @@ variables:
     dims: [lon, lat, time, typec3natg]
     formula: (FATES_CROWNAREA_PF(12+13))*FATES_FRACTION
     long_name: Emon.grassFracC3
-    sources: [{freq: mon, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
@@ -910,43 +887,38 @@ variables:
     dims: [lon, lat, time, typec4natg]
     formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[14], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.grassFracC4
-    sources: [{freq: mon, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
   grassFrac_tavg-u-hxy-u:
     description: Percentage of entire grid cell that is covered by natural grass.
     dims: [lon, lat, time, typenatgr]
-    sources: [{freq: yr, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
-    variants: [{formula: 'sumoverpft(FATES_CROWNAREA_PF, pftlist=[12, 13, 14], dim=''fates_levpft'')
-          *FATES_FRACTION', long_name: Eyr.grassFrac}, {formula: 'sumoverpft(FATES_CROWNAREA_PF,
-          pftlist=[12, 13, 14], dim=''fates_levpft'')*FATES_FRACTION', long_name: Lmon.grassFrac}]
 
   hfdsl_tavg-u-hxy-lnd:
     description: Ground heat flux at 3hr
     dims: [lon, lat, time]
     long_name: 3hr.hfdsl
-    sources: [{freq: 3hr, model_var: FGR}]
+    sources: [model_var: FGR]
     table: land
     units: W m-2
 
   hfls_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: LHFLX}]
+    sources: [model_var: LHFLX]
     table: atmos
     units: W m-2
-    variants: [{long_name: 3hr.hfls}, {long_name: Amon.hfls}, {long_name: day.hfls}]
 
   hfss_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: SHFLX}]
+    sources: [model_var: SHFLX]
     table: atmos
     units: W m-2
-    variants: [{long_name: 3hr.hfss}, {long_name: Amon.hfss}, {long_name: day.hfss}]
 
   hur_tavg-al-hxy-u:
     description: This is the relative humidity with respect to liquid water for T>
@@ -954,17 +926,16 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    sources: [{freq: day, model_var: RELHUM}]
+    sources: [model_var: RELHUM]
     table: atmos
     units: '%'
-    variants: [{long_name: CFday.hur}, {long_name: CFmon.hur}]
 
   hur_tavg-p19-hxy-air:
     description: This is the relative humidity with respect to liquid water for T>
       0 C, and with respect to ice for T<0 C.
     dims: [lon, lat, plev19, time]
     long_name: Amon.hur
-    sources: [{freq: mon, model_var: RELHUM}, model_var: RHW]
+    sources: [model_var: RELHUM, model_var: RHW]
     table: atmos
     units: '%'
 
@@ -973,7 +944,7 @@ variables:
       0 C, and with respect to ice for T<0 C.
     dims: [lon, lat, plev19, time]
     long_name: day.hur
-    sources: [{freq: day, model_var: RELHUM}]
+    sources: [model_var: RELHUM]
     table: atmos
     units: '%'
 
@@ -981,17 +952,16 @@ variables:
     description: The relative humidity with respect to liquid water for T> 0 C, and
       with respect to ice for T<0 C.
     dims: [lon, lat, time, height2m]
-    sources: [{freq: 6hr, model_var: RHREFHT}]
+    sources: [model_var: RHREFHT]
     table: atmos
     units: '%'
-    variants: [{long_name: 6hrPlev.hurs}, {long_name: Amon.hurs}, {long_name: day.hurs}]
 
   hurs_tmax-h2m-hxy-u:
     description: This is the relative humidity with respect to liquid water for T>
       0 C, and with respect to ice for T<0 C.
     dims: [lon, lat, time, height2m]
     long_name: day.hursmax
-    sources: [{freq: day, model_var: 'X: RHREFHT'}]
+    sources: [{model_var: 'X: RHREFHT'}]
     table: atmos
     units: '%'
 
@@ -1001,36 +971,32 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    sources: [{freq: day, model_var: Q}]
+    sources: [model_var: Q]
     table: atmos
     units: '1'
-    variants: [{long_name: CFday.hus}, {long_name: CFmon.hus}]
 
   hus_tavg-p19-hxy-u:
     description: Specific humidity is the mass fraction of water vapor in (moist)
       air.
     dims: [lon, lat, plev19, time]
-    sources: [{freq: mon, model_var: Q}]
+    sources: [model_var: Q]
     table: atmos
     units: '1'
-    variants: [{long_name: Amon.hus}, {long_name: day.hus}]
 
   huss_tavg-h2m-hxy-u:
     description: Near-surface (usually, 2 meter) specific humidity.
     dims: [lon, lat, time, height2m]
-    sources: [{freq: mon, model_var: QREFHT}]
+    sources: [model_var: QREFHT]
     table: atmos
     units: '1'
-    variants: [{long_name: Amon.huss}, {long_name: day.huss}]
 
   lai_tavg-u-hxy-lnd:
     description: A ratio obtained by dividing the total upper leaf surface area of
       vegetation by the (horizontal) surface area of the land on which it grows.
     dims: [lon, lat, time]
-    sources: [{freq: day, model_var: FATES_LAI}]
+    sources: [model_var: FATES_LAI]
     table: land
     units: '1'
-    variants: [{long_name: Eday.lai}, {long_name: Lmon.lai}]
 
   landCoverFrac_tavg-u-hxy-u:
     description: The categories may differ from model to model, depending on their  PFT
@@ -1039,7 +1005,7 @@ variables:
       that is land.
     dims: [lon, lat, vegtype, time]
     long_name: Lmon.landCoverFrac
-    sources: [{freq: mon, model_var: PCT_LANDUNIT}]
+    sources: [model_var: PCT_LANDUNIT]
     table: land
     units: '%'
 
@@ -1048,8 +1014,8 @@ variables:
     dims: [lon, lat, time]
     formula: BC_A+BC_AC+BC_AI+BC_AX+BC_N+BC_NI
     long_name: Eday.loadbc
-    sources: [{freq: day, model_var: BC_A}, model_var: BC_AC, model_var: BC_AI,
-      model_var: BC_AX, model_var: BC_N, model_var: BC_NI]
+    sources: [model_var: BC_A, model_var: BC_AC, model_var: BC_AI, model_var: BC_AX,
+      model_var: BC_N, model_var: BC_NI]
     table: atmos
     units: kg m-2
 
@@ -1058,7 +1024,7 @@ variables:
     dims: [lon, lat, time]
     formula: DST_A2+DST_A3
     long_name: Eday.loaddust
-    sources: [{freq: day, model_var: DST_A2}, model_var: DST_A3]
+    sources: [model_var: DST_A2, model_var: DST_A3]
     table: atmos
     units: kg m-2
 
@@ -1067,8 +1033,8 @@ variables:
     dims: [lon, lat, time]
     formula: SO4_A1*3+SO4_A2*3+SO4_AC*3+SO4_N*3+SO4_NA*3+SO4_PR*3
     long_name: Eday.loadso4
-    sources: [{freq: day, model_var: SO4_A1}, model_var: SO4_A2, model_var: SO4_AC,
-      model_var: SO4_N, model_var: SO4_NA, model_var: SO4_PR]
+    sources: [model_var: SO4_A1, model_var: SO4_A2, model_var: SO4_AC, model_var: SO4_N,
+      model_var: SO4_NA, model_var: SO4_PR]
     table: atmos
     units: kg m-2
 
@@ -1077,7 +1043,7 @@ variables:
     dims: [lon, lat, time]
     formula: SS_A1+SS_A2+SS_A3
     long_name: Eday.loadss
-    sources: [{freq: day, model_var: SS_A1}, model_var: SS_A2, model_var: SS_A3]
+    sources: [model_var: SS_A1, model_var: SS_A2, model_var: SS_A3]
     table: atmos
     units: kg m-2
 
@@ -1088,7 +1054,7 @@ variables:
     dims: [lon, lat, alevhalf, time]
     formula: CMFMC+CMFMCDZM
     long_name: Amon.mc
-    sources: [{freq: mon, model_var: CMFMC}, model_var: CMFMCDZM]
+    sources: [model_var: CMFMC, model_var: CMFMCDZM]
     table: atmos
     units: kg m-2 s-1
 
@@ -1097,54 +1063,48 @@ variables:
       model) leaving the land portion of the grid cell divided by the land area in
       the grid cell, averaged over the 3-hour interval.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: QRUNOFF}]
+    sources: [model_var: QRUNOFF]
     table: land
     units: kg m-2 s-1
-    variants: [{long_name: 3hr.mrro}, {long_name: day.mrro}, {long_name: Lmon.mrro}]
 
   mrrob_tavg-u-hxy-lnd:
     description: subsurface_runoff_flux
     dims: [lon, lat, time]
     long_name: Eday.mrrob
-    sources: [{freq: day, model_var: QDRAI}]
+    sources: [model_var: QDRAI]
     table: land
     units: kg m-2 s-1
 
   mrros_tavg-u-hxy-lnd:
     description: surface_runoff_flux
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: QOVER}]
+    sources: [model_var: QOVER]
     table: land
     units: kg m-2 s-1
-    variants: [{long_name: 3hr.mrros}, {long_name: Eday.mrros}, {long_name: Lmon.mrros}]
 
   mrsfl_tavg-sl-hxy-lnd:
     description: in each soil layer, the mass of water in ice phase.  Reported as
       "missing" for grid cells occupied entirely by "sea"
     dims: [lon, lat, sdepth, time]
-    sources: [{freq: day, model_var: SOILICE}]
+    sources: [model_var: SOILICE]
     table: land
     units: kg m-2
-    variants: [{long_name: Eday.mrsfl}, {long_name: Emon.mrsfl}]
 
   mrsll_tavg-sl-hxy-lnd:
     description: in each soil layer, the mass of water in liquid phase.  Reported
       as "missing" for grid cells occupied entirely by "sea"
     dims: [lon, lat, sdepth, time]
-    sources: [{freq: day, model_var: SOILLIQ}]
+    sources: [model_var: SOILLIQ]
     table: land
     units: kg m-2
-    variants: [{long_name: Eday.mrsll}, {long_name: Emon.mrsll}]
 
   mrso_tavg-u-hxy-lnd:
     description: the mass per unit area  (summed over all soil layers) of water in
       all phases.
     dims: [lon, lat, time]
-    sources: [{freq: day, model_var: TOTSOILLIQ}, model_var: TOTSOILICE]
+    sources: [model_var: TOTSOILLIQ, model_var: TOTSOILICE]
     table: land
     units: kg m-2
-    variants: [{formula: TOTSOILLIQ+TOTSOILICE, long_name: day.mrso}, {formula: TOTSOILLIQ+TOTSOILICE,
-        long_name: Lmon.mrso}]
 
   mrsofc_ti-u-hxy-lnd:
     description: 'reported "where land": divide the total water holding capacity of
@@ -1152,42 +1112,38 @@ variables:
       "missing" where the land fraction is 0.'
     dims: [lon, lat]
     long_name: fx.mrsofc
-    sources: [{freq: fx, model_var: SUCSAT}]
+    sources: [model_var: SUCSAT]
     table: land
     units: kg m-2
 
   mrsol_tavg-d10cm-hxy-lnd:
     description: the mass of water in all phases in a thin surface soil layer.
     dims: [lon, lat, time, sdepth10cm]
-    sources: [{freq: day, model_var: SOILWATER_10CM}]
+    sources: [model_var: SOILWATER_10CM]
     table: land
     units: kg m-2
-    variants: [{long_name: day.mrsos}, {long_name: Lmon.mrsos}]
 
   mrsol_tavg-sl-hxy-lnd:
     description: in each soil layer, the mass of water in all phases, including ice.  Reported
       as "missing" for grid cells occupied entirely by "sea"
     dims: [lon, lat, sdepth, time]
-    sources: [{freq: day, model_var: SOILLIQ}, model_var: SOILICE]
+    sources: [model_var: SOILLIQ, model_var: SOILICE]
     table: land
     units: kg m-2
-    variants: [{formula: SOILLIQ+SOILICE, long_name: Eday.mrsol}, {formula: SOILLIQ+SOILICE,
-        long_name: Emon.mrsol}]
 
   mrtws_tavg-u-hxy-lnd:
     description: canopy_and_surface_and_subsurface_water_amount
     dims: [lon, lat, time]
-    sources: [{freq: day, model_var: TWS}]
+    sources: [model_var: TWS]
     table: land
     units: kg m-2
-    variants: [{long_name: Eday.mrtws}, {long_name: Emon.mrtws}]
 
   nLand_tavg-u-hxy-lnd:
     description: Report missing data over ocean grid cells. For fractional land report
       value averaged over the land fraction.
     dims: [lon, lat, time]
     long_name: Emon.nLand
-    sources: [{freq: mon, model_var: TOTECOSYSN}]
+    sources: [model_var: TOTECOSYSN]
     table: land
     units: kg m-2
 
@@ -1195,7 +1151,7 @@ variables:
     description: SUM of ammonium over all soil layers
     dims: [lon, lat, time]
     long_name: Emon.nMineralNH4
-    sources: [{freq: mon, model_var: SMIN_NH4}]
+    sources: [model_var: SMIN_NH4]
     table: land
     units: kg m-2
 
@@ -1203,7 +1159,7 @@ variables:
     description: SUM of nitrate over all soil layers
     dims: [lon, lat, time]
     long_name: Emon.nMineralNO3
-    sources: [{freq: mon, model_var: SMIN_NO3}]
+    sources: [model_var: SMIN_NO3]
     table: land
     units: kg m-2
 
@@ -1211,7 +1167,7 @@ variables:
     description: SUM of ammonium, nitrite, nitrate, etc over all soil layers
     dims: [lon, lat, time]
     long_name: Emon.nMineral
-    sources: [{freq: mon, model_var: SMINN}]
+    sources: [model_var: SMINN]
     table: land
     units: kg m-2
 
@@ -1221,7 +1177,7 @@ variables:
     dims: [lon, lat, time]
     formula: SOIL1N+SOIL2N+SOIL3N
     long_name: Emon.nSoil
-    sources: [{freq: mon, model_var: SOIL1N}, model_var: SOIL2N, model_var: SOIL3N]
+    sources: [model_var: SOIL1N, model_var: SOIL2N, model_var: SOIL3N]
     table: land
     units: kg m-2
 
@@ -1232,7 +1188,7 @@ variables:
     dims: [lon, lat, time]
     formula: FCO2 /1000 / conv
     long_name: Lmon.nbp
-    sources: [{freq: mon, model_var: FCO2}, model_var: conv]
+    sources: [model_var: FCO2, model_var: conv]
     table: land
     units: kg m-2 s-1
 
@@ -1240,7 +1196,7 @@ variables:
     description: Net Ecosystem Exchange
     dims: [lon, lat, time]
     long_name: Emon.nep
-    sources: [{freq: mon, model_var: NEP}]
+    sources: [model_var: NEP]
     table: land
     units: kg m-2 s-1
 
@@ -1248,7 +1204,7 @@ variables:
     description: This is the rate of carbon uptake by leaves due to NPP
     dims: [lon, lat, time]
     long_name: Lmon.nppLeaf
-    sources: [{freq: mon, model_var: FATES_LEAF_ALLOC}]
+    sources: [model_var: FATES_LEAF_ALLOC]
     table: land
     units: kg m-2 s-1
 
@@ -1265,7 +1221,7 @@ variables:
       of A.'
     dims: [lon, lat, landuse, time]
     long_name: Emon.nppLut
-    sources: [{freq: mon, model_var: FATES_NPP_LU}]
+    sources: [model_var: FATES_NPP_LU]
     table: land
     units: kg m-2 s-1
 
@@ -1274,8 +1230,7 @@ variables:
     dims: [lon, lat, time]
     formula: (FATES_SEED_ALLOC+FATES_STORE_ALLOC)*FATES_FRACTION
     long_name: Emon.nppOther
-    sources: [{freq: mon, model_var: FATES_SEED_ALLOC}, model_var: FATES_STORE_ALLOC,
-      model_var: FATES_FRACTION]
+    sources: [model_var: FATES_SEED_ALLOC, model_var: FATES_STORE_ALLOC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1284,8 +1239,7 @@ variables:
     dims: [lon, lat, time]
     formula: (FATES_CROOT_ALLOC+FATES_FROOT_ALLOC)*FATES_FRACTION
     long_name: Lmon.nppRoot
-    sources: [{freq: mon, model_var: FATES_CROOT_ALLOC}, model_var: FATES_FROOT_ALLOC,
-      model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROOT_ALLOC, model_var: FATES_FROOT_ALLOC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1293,7 +1247,7 @@ variables:
     description: added for completeness with npp_root
     dims: [lon, lat, time]
     long_name: Emon.nppStem
-    sources: [{freq: mon, model_var: FATES_STEM_ALLOC}]
+    sources: [model_var: FATES_STEM_ALLOC]
     table: land
     units: kg m-2 s-1
 
@@ -1310,7 +1264,7 @@ variables:
       of A.'
     dims: [lon, lat, time]
     long_name: Lmon.npp
-    sources: [{freq: mon, model_var: FATES_NPP}]
+    sources: [model_var: FATES_NPP]
     table: land
     units: kg m-2 s-1
 
@@ -1319,7 +1273,7 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_NPP_PF, pftlist=[12, 13, 14], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.nppGrass
-    sources: [{freq: mon, model_var: FATES_NPP_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1328,7 +1282,7 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_NPP_PF, pftlist=[7, 8, 9, 10, 11], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.nppShrub
-    sources: [{freq: mon, model_var: FATES_NPP_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1337,7 +1291,7 @@ variables:
     dims: [lon, lat, time]
     formula: (sumoverpft(FATES_NPP_PF, pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.nppTree
-    sources: [{freq: mon, model_var: FATES_NPP_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1346,11 +1300,9 @@ variables:
       Altitude is the (geometric) height above the geoid, which is the reference geopotential
       surface. The geoid is similar to mean sea level.
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: PHIS}]
+    sources: [model_var: PHIS]
     table: land
     units: m
-    variants: [{long_name: ImonAnt.orog}, {long_name: ImonGre.orog}, {long_name: IyrAnt.orog},
-      {long_name: IyrGre.orog}]
 
   orog_ti-u-hxy-u:
     description: height above the geoid; as defined here, "the geoid" is a surface
@@ -1360,7 +1312,7 @@ variables:
       here is the height above the present-day geoid (0.0 over ocean).
     dims: [lon, lat]
     long_name: fx.orog
-    sources: [{freq: fx, model_var: PHIS}]
+    sources: [model_var: PHIS]
     table: land
     units: m
 
@@ -1369,43 +1321,38 @@ variables:
     dims: [lon, lat, time, typepasture]
     formula: (sumoverpft(FATES_PATCHAREA_LU, pftlist=[4], dim='fates_levlanduse'))*FATES_FRACTION
     long_name: Lmon.pastureFrac
-    sources: [{freq: mon, model_var: FATES_PATCHAREA_LU}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_PATCHAREA_LU, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
   pctisccp_tavg-u-hxy-cl:
     description: time-means are weighted by the ISCCP Total Cloud Fraction - see  https://www.cfmip.org/tools-and-data/cosp
     dims: [lon, lat, time]
-    sources: [{freq: day, model_var: MEANPTOP_ISCCP}, model_var: CLDTOT_ISCCP]
+    sources: [model_var: MEANPTOP_ISCCP, model_var: CLDTOT_ISCCP]
     table: atmos
     units: Pa
-    variants: [{formula: MEANPTOP_ISCCP/CLDTOT_ISCCP, long_name: CFday.pctisccp},
-      {formula: MEANPTOP_ISCCP/CLDTOT_ISCCP, long_name: CFmon.pctisccp}]
 
   pr_tavg-u-hxy-u:
     description: at surface; includes both liquid and solid phases.  This is the 3-hour
       mean precipitation flux.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: PRECT}]
+    sources: [model_var: PRECT]
     table: atmos
     units: kg m-2 s-1
-    variants: [{long_name: 3hr.pr}, {long_name: 6hrPlev.pr}, {formula: PRECT+PRECC,
-        long_name: Amon.pr}, {long_name: day.pr}, {long_name: E1hr.pr}]
 
   prc_tavg-u-hxy-u:
     description: at surface; includes both liquid and solid phases.
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: PRECC}]
+    sources: [model_var: PRECC]
     table: atmos
     units: kg m-2 s-1
-    variants: [{long_name: Amon.prc}, {long_name: day.prc}]
 
   prra_tavg-u-hxy-lnd:
     description: rainfall_flux
     dims: [lon, lat, time]
     formula: PRECT-PRECSC-PRECSL
     long_name: Eday.prra
-    sources: [{freq: day, model_var: PRECT}, model_var: PRECSC, model_var: PRECSL]
+    sources: [model_var: PRECT, model_var: PRECSC, model_var: PRECSL]
     table: atmos
     units: kg m-2 s-1
 
@@ -1413,18 +1360,16 @@ variables:
     description: at surface.  Includes precipitation of all forms water in the solid
       phase.  This is the 3-hour mean snowfall flux.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: PRECSC}, model_var: PRECSL]
+    sources: [model_var: PRECSC, model_var: PRECSL]
     table: atmos
     units: kg m-2 s-1
-    variants: [{formula: PRECSC+PRECSL, long_name: 3hr.prsn}, {formula: PRECSC+PRECSL,
-        long_name: Amon.prsn}, {formula: PRECSC+PRECSL, long_name: day.prsn}]
 
   prveg_tavg-u-hxy-lnd:
     description: the precipitation flux that is intercepted by the vegetation canopy
       (if present in model) before reaching the ground.
     dims: [lon, lat, time]
     long_name: Lmon.prveg
-    sources: [{freq: mon, model_var: QINTR}]
+    sources: [model_var: QINTR]
     table: land
     units: kg m-2 s-1
 
@@ -1432,34 +1377,31 @@ variables:
     description: Vertically integrated mass of water vapour through the atmospheric
       column
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: Q}]
+    sources: [model_var: Q]
     table: atmos
     units: kg m-2
-    variants: [{long_name: E3hr.prw}, {long_name: Eday.prw}]
 
   ps_tavg-u-hxy-u:
     description: surface pressure (not mean sea-level pressure), 2-D field to calculate
       the 3-D pressure field from hybrid coordinates
     dims: [lon, lat, time]
-    sources: [{freq: 1hr, model_var: PS}]
+    sources: [model_var: PS]
     table: atmos
     units: Pa
-    variants: [{long_name: AERhr.ps}, {long_name: Amon.ps}, {long_name: CFday.ps}]
 
   psl_tavg-u-hxy-u:
     description: Sea Level Pressure
     dims: [lon, lat, time]
-    sources: [{freq: 6hr, model_var: PSL}]
+    sources: [model_var: PSL]
     table: atmos
     units: Pa
-    variants: [{long_name: 6hrPlev.psl}, {long_name: Amon.psl}, {long_name: day.psl}]
 
   ptp_tavg-u-hxy-u:
     description: 2D monthly mean thermal tropopause calculated using WMO tropopause
       definition on 3d temperature
     dims: [lon, lat, time]
     long_name: AERmon.ptp
-    sources: [{freq: mon, model_var: TROP_P}]
+    sources: [model_var: TROP_P]
     table: atmos
     units: Pa
 
@@ -1467,7 +1409,7 @@ variables:
     description: water_flux_from_soil_layer_to_groundwater
     dims: [lon, lat, time]
     long_name: Eday.qgwr
-    sources: [{freq: day, model_var: QCHARGE}]
+    sources: [model_var: QCHARGE]
     table: land
     units: kg m-2 s-1
 
@@ -1475,7 +1417,7 @@ variables:
     description: added for completeness with Ra_root
     dims: [lon, lat, time]
     long_name: Emon.raLeaf
-    sources: [{freq: mon, model_var: FATES_LEAFMAINTAR}]
+    sources: [model_var: FATES_LEAFMAINTAR]
     table: land
     units: kg m-2 s-1
 
@@ -1486,7 +1428,7 @@ variables:
     dims: [lon, lat, landuse, time]
     formula: (FATES_GPP_LU-FATES_NPP_LU)*FATES_FRACTION
     long_name: Emon.raLut
-    sources: [{freq: mon, model_var: FATES_GPP_LU}, model_var: FATES_NPP_LU, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_GPP_LU, model_var: FATES_NPP_LU, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1497,7 +1439,7 @@ variables:
     dims: [lon, lat, time]
     formula: FROOTMAINTAR+CROOTMAINTAR
     long_name: Emon.raRoot
-    sources: [{freq: mon, model_var: FROOTMAINTAR}, model_var: CROOTMAINTAR]
+    sources: [model_var: FROOTMAINTAR, model_var: CROOTMAINTAR]
     table: land
     units: kg m-2 s-1
 
@@ -1505,7 +1447,7 @@ variables:
     description: added for completeness with Ra_root
     dims: [lon, lat, time]
     long_name: Emon.raStem
-    sources: [{freq: mon, model_var: FATES_LSTEMMAINTAR}]
+    sources: [model_var: FATES_LSTEMMAINTAR]
     table: land
     units: kg m-2 s-1
 
@@ -1515,7 +1457,7 @@ variables:
       Calculated on vegetation type.
     dims: [lon, lat, vegtype, time]
     long_name: Eday.raVgt
-    sources: [{freq: day, model_var: FATES_AUTORESP}]
+    sources: [model_var: FATES_AUTORESP]
     table: land
     units: kg m-2 s-1
 
@@ -1525,7 +1467,7 @@ variables:
     dims: [lon, lat, time]
     formula: FATES_AUTORESP*FATES_FRACTIONTION
     long_name: Lmon.ra
-    sources: [{freq: mon, model_var: FATES_AUTORESP}, model_var: FATES_FRACTIONTION]
+    sources: [model_var: FATES_AUTORESP, model_var: FATES_FRACTIONTION]
     table: land
     units: kg m-2 s-1
 
@@ -1535,7 +1477,7 @@ variables:
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[12, 13, 14], dim='fates_levpft')-sumoverpft(FATES_NPP_PF,
       pftlist=[12, 13, 14], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.raGrass
-    sources: [{freq: mon, model_var: FATES_GPP_PF}, model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_GPP_PF, model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1545,7 +1487,7 @@ variables:
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[7, 8, 9, 10, 11], dim='fates_levpft')-sumoverpft(FATES_NPP_PF,
       pftlist=[7, 8, 9, 10, 11], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.raShrub
-    sources: [{freq: mon, model_var: FATES_GPP_PF}, model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_GPP_PF, model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1555,7 +1497,7 @@ variables:
     formula: (sumoverpft(FATES_GPP_PF, pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft')-sumoverpft(FATES_NPP_PF,
       pftlist=[1, 2, 3, 4, 5, 6], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.raTree
-    sources: [{freq: mon, model_var: FATES_GPP_PF}, model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_GPP_PF, model_var: FATES_NPP_PF, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1568,7 +1510,7 @@ variables:
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
     long_name: Emon.reffclws
-    sources: [{freq: mon, model_var: REFFL}]
+    sources: [model_var: REFFL]
     table: atmos
     units: m
 
@@ -1576,11 +1518,9 @@ variables:
     description: Percentage of entire grid cell  that is land and is covered by  neither
       vegetation nor bare-soil (e.g., urban, ice, lakes, etc.)
     dims: [lon, lat, time, typeresidual]
-    sources: [{freq: yr, model_var: FATES_FRACTION}]
+    sources: [model_var: FATES_FRACTION]
     table: land
     units: '%'
-    variants: [{formula: 1-FATES_FRACTION, long_name: Eyr.residualFrac}, {formula: 1-FATES_FRACTIONTION,
-        long_name: Lmon.residualFrac}]
 
   rhLitter_tavg-u-hxy-lnd:
     description: Needed to calculate litter bulk turnover time. Includes respiration
@@ -1588,7 +1528,7 @@ variables:
     dims: [lon, lat, time]
     formula: LITTERC_HR /1000
     long_name: Emon.rhLitter
-    sources: [{freq: mon, model_var: LITTERC_HR}]
+    sources: [model_var: LITTERC_HR]
     table: land
     units: kg m-2 s-1
 
@@ -1597,7 +1537,7 @@ variables:
     dims: [lon, lat, time]
     formula: SOILC_HR /1000
     long_name: Emon.rhSoil
-    sources: [{freq: mon, model_var: SOILC_HR}]
+    sources: [model_var: SOILC_HR]
     table: land
     units: kg m-2 s-1
 
@@ -1606,7 +1546,7 @@ variables:
       respiration on land (respiration by consumers), calculated on vegetation type.
     dims: [lon, lat, vegtype, time]
     long_name: Eday.rhVgt
-    sources: [{freq: day, model_var: FATES_HET_RESP}]
+    sources: [model_var: FATES_HET_RESP]
     table: land
     units: kg m-2 s-1
 
@@ -1616,7 +1556,7 @@ variables:
     dims: [lon, lat, time]
     formula: FATES_HET_RESP*FATES_FRACTION
     long_name: Lmon.rh
-    sources: [{freq: mon, model_var: FATES_HET_RESP}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_HET_RESP, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1624,31 +1564,29 @@ variables:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
     long_name: CFmon.rldcs
-    sources: [{freq: mon, model_var: FDLC}]
+    sources: [model_var: FDLC]
     table: atmos
     units: W m-2
 
   rlds_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: FLDS}]
+    sources: [model_var: FLDS]
     table: atmos
     units: W m-2
-    variants: [{long_name: 3hr.rlds}, {long_name: Amon.rlds}, {long_name: day.rlds}]
 
   rldscs_tavg-u-hxy-u:
     description: Surface downwelling clear-sky longwave radiation
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: FLDSC}]
+    sources: [model_var: FLDSC]
     table: atmos
     units: W m-2
-    variants: [{long_name: Amon.rldscs}, {long_name: CFday.rldscs}]
 
   rls_tavg-u-hxy-u:
     description: Net longwave surface radiation
     dims: [lon, lat, time]
     long_name: Emon.rls
-    sources: [{freq: mon, model_var: FLNS}]
+    sources: [model_var: FLNS]
     table: atmos
     units: W m-2
 
@@ -1656,7 +1594,7 @@ variables:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
     long_name: CFmon.rlu
-    sources: [{freq: mon, model_var: FUL}]
+    sources: [model_var: FUL]
     table: atmos
     units: W m-2
 
@@ -1664,50 +1602,44 @@ variables:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
     long_name: CFmon.rlucs
-    sources: [{freq: mon, model_var: FULC}]
+    sources: [model_var: FULC]
     table: atmos
     units: W m-2
 
   rlus_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: FLDS}, model_var: FLNS]
+    sources: [model_var: FLDS, model_var: FLNS]
     table: atmos
     units: W m-2
-    variants: [{formula: FLDS+FLNS, long_name: 3hr.rlus}, {formula: FLDS+FLNS, long_name: Amon.rlus},
-      {formula: FLDS+FLNS, long_name: day.rlus}]
 
   rluscs_tavg-u-hxy-u:
     description: Surface Upwelling Clear-sky Longwave Radiation
     dims: [lon, lat, time]
     long_name: Amon.rluscs
-    sources: [{freq: mon, model_var: FULC}]
+    sources: [model_var: FULC]
     table: atmos
     units: W m-2
 
   rlut_tavg-u-hxy-u:
     description: at the top of the atmosphere (to be compared with satellite measurements)
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: FSNTOA}, model_var: FSNT, model_var: FLNT]
+    sources: [model_var: FSNTOA, model_var: FSNT, model_var: FLNT]
     table: atmos
     units: W m-2
-    variants: [{formula: FSNTOA-FSNT+FLNT, long_name: Amon.rlut}, {formula: FSNTOA-FSNT+FLNT,
-        long_name: day.rlut}, {formula: FSNTOA-FSNT+FLNT, long_name: E3hr.rlut}]
 
   rlutcs_tavg-u-hxy-u:
     description: Upwelling clear-sky longwave radiation at top of atmosphere
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: FSNTOAC}, model_var: FSNTC, model_var: FLNTC]
+    sources: [model_var: FSNTOAC, model_var: FSNTC, model_var: FLNTC]
     table: atmos
     units: W m-2
-    variants: [{formula: FSNTOAC-FSNTC+FLNTC, long_name: Amon.rlutcs}, {formula: FSNTOAC-FSNTC+FLNTC,
-        long_name: CFday.rlutcs}, {formula: FSNTOAC-FSNTC+FLNTC, long_name: E3hr.rlutcs}]
 
   rsd_tavg-alh-hxy-u:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
     long_name: CFmon.rsd
-    sources: [{freq: mon, model_var: FDS}]
+    sources: [model_var: FDS]
     table: atmos
     units: W m-2
 
@@ -1715,7 +1647,7 @@ variables:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
     long_name: CFmon.rsdcs
-    sources: [{freq: mon, model_var: FDSC}]
+    sources: [model_var: FDSC]
     table: atmos
     units: W m-2
 
@@ -1724,7 +1656,7 @@ variables:
       computation of surface albedo.
     dims: [lon, lat, time]
     long_name: Emon.rsds
-    sources: [{freq: mon, model_var: FSDS}]
+    sources: [model_var: FSDS]
     table: land
     units: W m-2
 
@@ -1734,25 +1666,23 @@ variables:
       albedo.
     dims: [lon, lat, time]
     long_name: Emon.rsdss
-    sources: [{freq: mon, model_var: FSDS}]
+    sources: [model_var: FSDS]
     table: land
     units: W m-2
 
   rsds_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: FSDS}]
+    sources: [model_var: FSDS]
     table: atmos
     units: W m-2
-    variants: [{long_name: 3hr.rsds}, {long_name: Amon.rsds}, {long_name: day.rsds}]
 
   rsdscs_tavg-u-hxy-u:
     description: Surface solar irradiance clear sky for UV calculations
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: FSDSC}]
+    sources: [model_var: FSDSC]
     table: atmos
     units: W m-2
-    variants: [{long_name: Amon.rsdscs}, {long_name: CFday.rsdscs}]
 
   rsdsdiff_tavg-u-hxy-u:
     description: Surface downwelling solar irradiance from diffuse radiation for UV
@@ -1760,24 +1690,22 @@ variables:
     dims: [lon, lat, time]
     formula: SOLLD+SOLSD
     long_name: Eday.rsdsdiff
-    sources: [{freq: day, model_var: SOLLD}, model_var: SOLSD]
+    sources: [model_var: SOLLD, model_var: SOLSD]
     table: atmos
     units: W m-2
 
   rsdt_tavg-u-hxy-u:
     description: at the top of the atmosphere
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: FSNTOA}, model_var: FSUTOA]
+    sources: [model_var: FSNTOA, model_var: FSUTOA]
     table: atmos
     units: W m-2
-    variants: [{formula: FSNTOA+FSUTOA, long_name: Amon.rsdt}, {formula: FSNTOA+FSUTOA,
-        long_name: CFday.rsdt}]
 
   rss_tavg-u-hxy-u:
     description: Net downward shortwave radiation at the surface
     dims: [lon, lat, time]
     long_name: Emon.rss
-    sources: [{freq: mon, model_var: FSNS}]
+    sources: [model_var: FSNS]
     table: atmos
     units: W m-2
 
@@ -1785,7 +1713,7 @@ variables:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
     long_name: CFmon.rsu
-    sources: [{freq: mon, model_var: FUS}]
+    sources: [model_var: FUS]
     table: atmos
     units: W m-2
 
@@ -1793,7 +1721,7 @@ variables:
     description: Includes also the fluxes at the surface and TOA.
     dims: [lon, lat, alevhalf, time]
     long_name: CFmon.rsucs
-    sources: [{freq: mon, model_var: FUSC}]
+    sources: [model_var: FUSC]
     table: atmos
     units: W m-2
 
@@ -1802,7 +1730,7 @@ variables:
       computation of surface albedo.
     dims: [lon, lat, time]
     long_name: Emon.rsus
-    sources: [{freq: mon, model_var: FSR}]
+    sources: [model_var: FSR]
     table: land
     units: W m-2
 
@@ -1812,7 +1740,7 @@ variables:
     dims: [lon, lat, time]
     formula: SNOFSRVI+SNOFSRVD+SNOFSRNI+SNOFSRND
     long_name: Emon.rsuss
-    sources: [{freq: mon, model_var: SNOFSRVI}, model_var: SNOFSRVD, model_var: SNOFSRNI,
+    sources: [model_var: SNOFSRVI, model_var: SNOFSRVD, model_var: SNOFSRNI,
       model_var: SNOFSRND]
     table: land
     units: W m-2
@@ -1820,37 +1748,30 @@ variables:
   rsus_tavg-u-hxy-u:
     description: This is the 3-hour mean flux.
     dims: [lon, lat, time]
-    sources: [{freq: 3hr, model_var: FSDS}, model_var: FSNS]
+    sources: [model_var: FSDS, model_var: FSNS]
     table: atmos
     units: W m-2
-    variants: [{formula: FSDS-FSNS, long_name: 3hr.rsus}, {formula: FSDS-FSNS, long_name: Amon.rsus},
-      {formula: FSDS-FSNS, long_name: day.rsus}]
 
   rsuscs_tavg-u-hxy-u:
     description: Surface Upwelling Clear-sky Shortwave Radiation
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: FSDSC}, model_var: FSNSC]
+    sources: [model_var: FSDSC, model_var: FSNSC]
     table: atmos
     units: W m-2
-    variants: [{formula: FSDSC-FSNSC, long_name: Amon.rsuscs}, {formula: FSDSC-FSNSC,
-        long_name: CFday.rsuscs}]
 
   rsut_tavg-u-hxy-u:
     description: at the top of the atmosphere
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: FSUTOA}]
+    sources: [model_var: FSUTOA]
     table: atmos
     units: W m-2
-    variants: [{long_name: Amon.rsut}, {long_name: CFday.rsut}, {long_name: E3hr.rsut}]
 
   rsutcs_tavg-u-hxy-u:
     description: Calculated in the absence of clouds.
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: SOLIN}, model_var: FSNTOAC]
+    sources: [model_var: SOLIN, model_var: FSNTOAC]
     table: atmos
     units: W m-2
-    variants: [{formula: SOLIN-FSNTOAC, long_name: Amon.rsutcs}, {formula: SOLIN-FSNTOAC,
-        long_name: CFday.rsutcs}, {formula: SOLIN-FSNTOAC, long_name: E3hr.rsutcs}]
 
   rtmt_tavg-u-hxy-u:
     description: i.e., at the top of that portion of the atmosphere where dynamics
@@ -1859,18 +1780,16 @@ variables:
     dims: [lon, lat, time]
     formula: FSNT-FLNT
     long_name: Amon.rtmt
-    sources: [{freq: mon, model_var: FSNT}, model_var: FLNT]
+    sources: [model_var: FSNT, model_var: FLNT]
     table: atmos
     units: W m-2
 
   sfcWind_tavg-h10m-hxy-u:
     description: near-surface (usually, 10 meters) wind speed.
     dims: [lon, lat, time, height10m]
-    sources: [{freq: 6hr, model_var: U10}]
+    sources: [model_var: U10]
     table: atmos
     units: m s-1
-    variants: [{long_name: 6hrPlev.sfcWind}, {long_name: Amon.sfcWind}, {long_name: day.sfcWind},
-      {long_name: E3hr.sfcWind}]
 
   sftgif_tavg-u-hxy-u:
     description: Percentage of grid cell covered by land ice (ice sheet, ice shelf,
@@ -1878,7 +1797,7 @@ variables:
     dims: [lon, lat, time]
     formula: sumoverpft(PCT_LANDUNIT, pftlist=[4], dim='ltype')
     long_name: LImon.sftgif
-    sources: [{freq: mon, model_var: PCT_LANDUNIT}]
+    sources: [model_var: PCT_LANDUNIT]
     table: land
     units: '%'
 
@@ -1886,25 +1805,22 @@ variables:
     description: Percentage of horizontal area occupied by land.
     dims: [lon, lat]
     long_name: fx.sftlf
-    sources: [{freq: fx, model_var: LANDFRAC}]
+    sources: [model_var: LANDFRAC]
     table: atmos
     units: '%'
 
   shrubFrac_tavg-u-hxy-u:
     description: Percentage of entire grid cell  that is covered by shrub.
     dims: [lon, lat, time, typeshrub]
-    sources: [{freq: yr, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
-    variants: [{formula: 'sumoverpft(FATES_CROWNAREA_PF, pftlist=[7, 8, 9, 10, 11],
-          dim=''fates_levpft'') *FATES_FRACTION', long_name: Eyr.shrubFrac}, {formula: 'sumoverpft(FATES_CROWNAREA_PF,
-          pftlist=[7, 8, 9, 10, 11], dim=''fates_levpft'') *FATES_FRACTION', long_name: Lmon.shrubFrac}]
 
   slthick_ti-sl-hxy-lnd:
     description: Thickness of Soil Layers
     dims: [lon, lat, sdepth]
     long_name: Efx.slthick
-    sources: [{freq: fx, model_var: DZSOI}]
+    sources: [model_var: DZSOI]
     table: land
     units: m
 
@@ -1914,7 +1830,7 @@ variables:
     dims: [lon, lat, time]
     formula: H2OSFC+ VOLR
     long_name: Eday.sw
-    sources: [{freq: day, model_var: H2OSFC}, model_var: VOLR]
+    sources: [model_var: H2OSFC, model_var: VOLR]
     table: land
     units: kg m-2
 
@@ -1928,7 +1844,7 @@ variables:
     dims: [lon, lat, landuse, time]
     formula: SNOWICE+SNOWLIQ
     long_name: Emon.sweLut
-    sources: [{freq: mon, model_var: SNOWICE}, model_var: SNOWLIQ]
+    sources: [model_var: SNOWICE, model_var: SNOWLIQ]
     table: land
     units: m
 
@@ -1936,7 +1852,7 @@ variables:
     description: Air temperature at 700hPa
     dims: [lon, lat, time, p700]
     long_name: CFday.ta700
-    sources: [{freq: day, model_var: T700}]
+    sources: [model_var: T700]
     table: atmos
     units: K
 
@@ -1944,7 +1860,7 @@ variables:
     description: Air temperature at 850hPa
     dims: [lon, lat, time, p850]
     long_name: Eday.ta850
-    sources: [{freq: day, model_var: T850}]
+    sources: [model_var: T850]
     table: atmos
     units: K
 
@@ -1953,59 +1869,53 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    sources: [{freq: day, model_var: T}]
+    sources: [model_var: T]
     table: atmos
     units: K
-    variants: [{long_name: CFday.ta}, {long_name: CFmon.ta}]
 
   ta_tavg-p19-hxy-air:
     description: Air Temperature
     dims: [lon, lat, plev19, time]
-    sources: [{freq: mon, model_var: T}]
+    sources: [model_var: T]
     table: atmos
     units: K
-    variants: [{long_name: Amon.ta}, {long_name: day.ta}]
 
   ta_tavg-p39-hy-air:
     description: Air Temperature
     dims: [lat, plev39, time]
-    sources: [{freq: mon, model_var: T}]
+    sources: [model_var: T]
     table: atmos
     units: K
-    variants: [{long_name: AERmonZ.ta}, {long_name: EdayZ.ta}]
 
   tasLut_tavg-h2m-hxy-multi:
     description: Air temperature is the bulk temperature of the air, not the surface
       (skin) temperature.
     dims: [lon, lat, landuse, time, height2m]
     long_name: Emon.tasLut
-    sources: [{freq: mon, model_var: TSA}]
+    sources: [model_var: TSA]
     table: land
     units: K
 
   tas_tavg-h2m-hxy-u:
     description: near-surface (usually, 2 meter) air temperature
     dims: [lon, lat, time, height2m]
-    sources: [{freq: 6hr, model_var: TREFHT}]
+    sources: [model_var: TREFHT]
     table: atmos
     units: K
-    variants: [{long_name: 6hrPlev.tas}, {long_name: AERhr.tas}, {long_name: Amon.tas},
-      {long_name: day.tas}]
 
   tas_tavg-u-hxy-u:
     description: Hourly Temperature at 2m above the surface
     dims: [lon, lat, time]
-    sources: [{freq: 1hr, model_var: TSA}]
+    sources: [model_var: TSA]
     table: land
     units: K
-    variants: [{long_name: E1hr.tas}, {long_name: E1hr.tasSouth30}]
 
   tas_tmax-h2m-hxy-u:
     description: 'maximum near-surface (usually, 2 meter) air temperature (add cell_method
       attribute "time: max")'
     dims: [lon, lat, time, height2m]
     long_name: day.tasmax
-    sources: [{freq: day, model_var: TREFHTMX}]
+    sources: [model_var: TREFHTMX]
     table: atmos
     units: K
 
@@ -2013,7 +1923,7 @@ variables:
     description: monthly mean of the daily-maximum near-surface air temperature.
     dims: [lon, lat, time4, height2m]
     long_name: Amon.tasmax
-    sources: [{freq: mon, model_var: TREFMXAV}]
+    sources: [model_var: TREFMXAV]
     table: atmos
     units: K
 
@@ -2022,25 +1932,23 @@ variables:
       attribute "time: min")'
     dims: [lon, lat, time, height2m]
     long_name: day.tasmin
-    sources: [{freq: day, model_var: TREFHTMN}]
+    sources: [model_var: TREFHTMN]
     table: atmos
     units: K
 
   tauu_tavg-u-hxy-u:
     description: Downward eastward wind stress at the surface
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: TAUX}]
+    sources: [model_var: TAUX]
     table: atmos
     units: Pa
-    variants: [{long_name: Amon.tauu}, {long_name: Eday.tauu}]
 
   tauv_tavg-u-hxy-u:
     description: Downward northward wind stress at the surface
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: TAUY}]
+    sources: [model_var: TAUY]
     table: atmos
     units: Pa
-    variants: [{long_name: Amon.tauv}, {long_name: Eday.tauv}]
 
   tnta_tavg-al-hxy-u:
     description: Tendency of Air Temperature due to Advection
@@ -2048,7 +1956,7 @@ variables:
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
     long_name: CFmon.tnta
-    sources: [{freq: mon, model_var: DTCORE}]
+    sources: [model_var: DTCORE]
     table: atmos
     units: K s-1
 
@@ -2058,7 +1966,7 @@ variables:
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
     long_name: AERmon.tntrl
-    sources: [{freq: mon, model_var: QRL}]
+    sources: [model_var: QRL]
     table: atmos
     units: K s-1
 
@@ -2068,7 +1976,7 @@ variables:
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
     long_name: AERmon.tntrs
-    sources: [{freq: mon, model_var: QRS}]
+    sources: [model_var: QRS]
     table: atmos
     units: K s-1
 
@@ -2076,7 +1984,7 @@ variables:
     description: Transpiration (may include dew formation as a negative flux).
     dims: [lon, lat, time]
     long_name: Lmon.tran
-    sources: [{freq: mon, model_var: QVEGT}]
+    sources: [model_var: QVEGT]
     table: land
     units: kg m-2 s-1
 
@@ -2084,7 +1992,7 @@ variables:
     description: Transpiration
     dims: [lon, lat, time]
     long_name: 3hr.tran
-    sources: [{freq: 3hr, model_var: QVEGT}]
+    sources: [model_var: QVEGT]
     table: land
     units: kg m-2 s-1
 
@@ -2094,7 +2002,7 @@ variables:
     dims: [lon, lat, time, typetreebd]
     formula: (FATES_CROWNAREA_PF(5:6)*FATES_FRACTION
     long_name: Emon.treeFracBdlDcd
-    sources: [{freq: mon, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
@@ -2104,7 +2012,7 @@ variables:
     dims: [lon, lat, time, typetreebe]
     formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[1, 4], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.treeFracBdlEvg
-    sources: [{freq: mon, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
@@ -2114,7 +2022,7 @@ variables:
     dims: [lon, lat, time, typetreend]
     formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[3], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.treeFracNdlDcd
-    sources: [{freq: mon, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
@@ -2124,51 +2032,46 @@ variables:
     dims: [lon, lat, time, typetreene]
     formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[2], dim='fates_levpft'))*FATES_FRACTION
     long_name: Emon.treeFracNdlEvg
-    sources: [{freq: mon, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
   treeFrac_tavg-u-hxy-u:
     description: Percentage of entire grid cell  that is covered by trees.
     dims: [lon, lat, time, typetree]
-    sources: [{freq: yr, model_var: FATES_CROWNAREA_PF}, model_var: FATES_FRACTION]
+    sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
-    variants: [{formula: 'sumoverpft(FATES_CROWNAREA_PF, pftlist=[1, 2, 3, 4, 5, 6],
-          dim=''fates_levpft'') *FATES_FRACTION', long_name: Eyr.treeFrac}, {formula: 'sumoverpft(FATES_CROWNAREA_PF,
-          pftlist=[1, 2, 3, 4, 5, 6], dim=''fates_levpft'') *FATES_FRACTION', long_name: Lmon.treeFrac}]
 
   tsLut_tavg-u-hxy-multi:
     description: Surface temperature (i.e. temperature at which long-wave radiation
       emitted)
     dims: [lon, lat, landuse, time]
     long_name: Emon.tslsiLut
-    sources: [{freq: mon, model_var: TSKIN}]
+    sources: [model_var: TSKIN]
     table: land
     units: K
 
   ts_tavg-u-hxy-u:
     description: Surface temperature (skin for open ocean)
     dims: [lon, lat, time]
-    sources: [{freq: mon, model_var: TS}]
+    sources: [model_var: TS]
     table: atmos
     units: K
-    variants: [{long_name: Amon.ts}, {long_name: Eday.ts}]
 
   tsl_tavg-sl-hxy-lnd:
     description: Temperature of each soil layer.  Reported as "missing" for grid cells
       occupied entirely by "sea".
     dims: [lon, lat, sdepth, time]
-    sources: [{freq: day, model_var: TSOI}]
+    sources: [model_var: TSOI]
     table: land
     units: K
-    variants: [{long_name: Eday.tsl}, {long_name: Lmon.tsl}]
 
   tslsi_tavg-u-hxy-u:
     description: Surface temperature of all surfaces except open ocean.
     dims: [lon, lat, time]
     long_name: day.tslsi
-    sources: [{freq: day, model_var: TSA}]
+    sources: [model_var: TSA]
     table: land
     units: K
 
@@ -2177,50 +2080,45 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    sources: [{freq: mon, model_var: U}]
+    sources: [model_var: U]
     table: atmos
     units: m s-1
-    variants: [{long_name: AERmon.ua}, {long_name: CFday.ua}]
 
   ua_tavg-p19-hxy-air:
     description: Zonal wind (positive in a eastward direction).
     dims: [lon, lat, plev19, time]
-    sources: [{freq: mon, model_var: U}]
+    sources: [model_var: U]
     table: atmos
     units: m s-1
-    variants: [{long_name: Amon.ua}, {long_name: day.ua}]
 
   ua_tavg-p39-hy-air:
     description: Zonal wind (positive in a eastward direction).
     dims: [lat, plev39, time]
-    sources: [{freq: mon, model_var: U}]
+    sources: [model_var: U]
     table: atmos
     units: m s-1
-    variants: [{long_name: AERmonZ.ua}, {long_name: EdayZ.ua}]
 
   va_tavg-al-hxy-u:
     description: Meridional wind (positive in a northward direction).
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    sources: [{freq: mon, model_var: V}]
+    sources: [model_var: V]
     table: atmos
     units: m s-1
-    variants: [{long_name: AERmon.va}, {long_name: CFday.va}]
 
   va_tavg-p19-hxy-air:
     description: Meridional wind (positive in a northward direction).
     dims: [lon, lat, plev19, time]
-    sources: [{freq: mon, model_var: V}]
+    sources: [model_var: V]
     table: atmos
     units: m s-1
-    variants: [{long_name: Amon.va}, {long_name: day.va}]
 
   va_tavg-p39-hy-air:
     description: Meridional wind (positive in a northward direction).
     dims: [lat, plev39, time]
     long_name: AERmonZ.va
-    sources: [{freq: mon, model_var: V}]
+    sources: [model_var: V]
     table: atmos
     units: m s-1
 
@@ -2228,17 +2126,15 @@ variables:
     description: Percentage of grid cell that is covered by vegetation.This SHOULD
       be the sum of tree, grass (natural and pasture), crop and shrub fractions.
     dims: [lon, lat, time, typeveg]
-    sources: [{freq: mon, model_var: FATES_AREA_PLANTS}]
+    sources: [model_var: FATES_AREA_PLANTS]
     table: land
     units: '%'
-    variants: [{long_name: Emon.vegFrac}, {formula: (sum(FATES_CROWNAREA_PF))*FATES_FRACTION,
-        long_name: Eyr.vegFrac}]
 
   vegHeight_tavg-u-hxy-ng:
     description: Vegetation height averaged over the grass fraction of a grid cell.
     dims: [lon, lat, time]
     long_name: Emon.vegHeightGrass
-    sources: [{freq: mon, model_var: FATES_CA_WEIGHTED_HEIGHT}]
+    sources: [model_var: FATES_CA_WEIGHTED_HEIGHT]
     table: land
     units: m
 
@@ -2247,7 +2143,7 @@ variables:
       vegetated fraction of a grid cell.
     dims: [lon, lat, time]
     long_name: Emon.vegHeight
-    sources: [{freq: mon, model_var: FATES_CA_WEIGHTED_HEIGHT}]
+    sources: [model_var: FATES_CA_WEIGHTED_HEIGHT]
     table: land
     units: m
 
@@ -2256,7 +2152,7 @@ variables:
       the vertical component of velocity in pressure coordinates (positive down)
     dims: [lon, lat, time, p500]
     long_name: CFday.wap500
-    sources: [{freq: day, model_var: OMEGA500}]
+    sources: [model_var: OMEGA500]
     table: atmos
     units: Pa s-1
 
@@ -2267,7 +2163,7 @@ variables:
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
     long_name: CFday.wap
-    sources: [{freq: day, model_var: OMEGA}]
+    sources: [model_var: OMEGA]
     table: atmos
     units: Pa s-1
 
@@ -2276,7 +2172,7 @@ variables:
       of velocity in pressure coordinates (positive down)
     dims: [lon, lat, plev19, time]
     long_name: Amon.wap
-    sources: [{freq: mon, model_var: OMEGA}]
+    sources: [model_var: OMEGA]
     table: atmos
     units: Pa s-1
 
@@ -2285,7 +2181,7 @@ variables:
       of velocity in pressure coordinates (positive down)
     dims: [lon, lat, plev19, time]
     long_name: day.wap
-    sources: [{freq: day, model_var: OMEGA}]
+    sources: [model_var: OMEGA]
     table: atmos
     units: Pa s-1
 
@@ -2296,7 +2192,7 @@ variables:
       season).
     dims: [lon, lat, time]
     long_name: Emon.wetlandCH4
-    sources: [{freq: mon, model_var: FCH4}]
+    sources: [model_var: FCH4]
     table: land
     units: kg m-2 s-1
 
@@ -2307,7 +2203,7 @@ variables:
       during the growing season).
     dims: [lon, lat, time]
     long_name: Emon.wetlandCH4prod
-    sources: [{freq: mon, model_var: CH4PROD}]
+    sources: [model_var: CH4PROD]
     table: land
     units: kg m-2 s-1
 
@@ -2316,7 +2212,7 @@ variables:
       if  fixed percentage is used, or time series if values are determined dynamically.
     dims: [lon, lat, time, typewetla]
     long_name: Emon.wetlandFrac
-    sources: [{freq: mon, model_var: FINUNDATED}]
+    sources: [model_var: FINUNDATED]
     table: land
     units: '%'
 
@@ -2324,23 +2220,22 @@ variables:
     description: depth_of_soil_moisture_saturation
     dims: [lon, lat, time]
     long_name: Eday.wtd
-    sources: [{freq: day, model_var: ZWT}]
+    sources: [model_var: ZWT]
     table: land
     units: m
 
   zg_tavg-1000hPa-hxy-air:
     description: Geopotential height on the 1000 hPa surface
     dims: [lon, lat, time, p1000]
-    sources: [{freq: 6hr, model_var: Z1000}]
+    sources: [model_var: Z1000]
     table: atmos
     units: m
-    variants: [{long_name: 6hrPlev.zg1000}, {long_name: AERday.zg1000}]
 
   zg_tavg-500hPa-hxy-air:
     description: geopotential height on the 500 hPa surface
     dims: [lon, lat, time, p500]
     long_name: AERday.zg500
-    sources: [{freq: day, model_var: Z500}]
+    sources: [model_var: Z500]
     table: atmos
     units: m
 
@@ -2353,10 +2248,9 @@ variables:
     dims: [lon, lat, lev, time]
     levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
       units: '1'}
-    sources: [{freq: mon, model_var: Z3}]
+    sources: [model_var: Z3]
     table: atmos
     units: m
-    variants: [{long_name: AERmon.zg}, {long_name: CFday.zg}]
 
   zg_tavg-p19-hxy-air:
     description: Geopotential is the sum of the specific gravitational potential energy
@@ -2365,10 +2259,9 @@ variables:
       It is numerically similar to the altitude (or geometric height) and not to the
       quantity with standard name height, which is relative to the surface.
     dims: [lon, lat, plev19, time]
-    sources: [{freq: mon, model_var: Z3}]
+    sources: [model_var: Z3]
     table: atmos
     units: m
-    variants: [{long_name: Amon.zg}, {long_name: day.zg}]
 
   zg_tavg-p39-hy-air:
     description: Geopotential is the sum of the specific gravitational potential energy
@@ -2377,16 +2270,15 @@ variables:
       It is numerically similar to the altitude (or geometric height) and not to the
       quantity with standard name height, which is relative to the surface.
     dims: [lat, plev39, time]
-    sources: [{freq: mon, model_var: Z3}]
+    sources: [model_var: Z3]
     table: atmos
     units: m
-    variants: [{long_name: AERmonZ.zg}, {long_name: EdayZ.zg}]
 
   ztp_tavg-u-hxy-u:
     description: 2D monthly mean thermal tropopause calculated using WMO tropopause
       definition on 3d temperature
     dims: [lon, lat, time]
     long_name: AERmon.ztp
-    sources: [{freq: mon, model_var: TROP_Z}]
+    sources: [model_var: TROP_Z]
     table: atmos
     units: m

--- a/data/noresm_to_cmip7_seaice.yaml
+++ b/data/noresm_to_cmip7_seaice.yaml
@@ -694,4 +694,3 @@ variables:
     sources: [{freq: day, model_var: sivol_d}, {freq: mon, model_var: sivol}]
     table: seaIce
     units: m3 m-3
-

--- a/data/noresm_to_cmip7_seaice.yaml
+++ b/data/noresm_to_cmip7_seaice.yaml
@@ -1,0 +1,697 @@
+dataset_overrides: {institution_id: NCAR, nominal_resolution: 100 km, source_id: CESM3}
+
+variables:
+
+  siage_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siage_d}, {freq: mon, model_var: siage}]
+    table: seaIce
+    units: yr
+
+  sialgc_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sialgc_d}, {freq: mon, model_var: sialgc}]
+    table: seaIce
+    units: kg m-2
+
+  siarea_tavg-u-hm-u:
+    dims: [time]
+    sources: [{alias: siconc, freq: day, model_var: siconc_d}, {freq: mon, model_var: siconc},
+      model_var: tarea]
+    table: seaIce
+    units: m2
+    variants: [{formula: '(siconc * tarea / 100.).where(siconc.coords[''TLAT''] >
+          0).sum(dim=[''nj'', ''ni''])', long_name: Sea Ice Area (Northern Hemisphere),
+        region: nh}, {formula: '(siconc * tarea / 100.).where(siconc.coords[''TLAT'']
+          < 0).sum(dim=[''nj'', ''ni''])', long_name: Sea Ice Area (Southern Hemisphere),
+        region: sh}]
+
+  sichl_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sichl_d}, {freq: mon, model_var: sichl}]
+    table: seaIce
+    units: kg m-2
+
+  sicompstren_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sicompstren_d}, {freq: mon, model_var: sicompstren}]
+    table: seaIce
+    units: N m-1
+
+  siconc_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siconc_d}, {freq: mon, model_var: siconc}]
+    table: seaIce
+    units: '%'
+
+  siconc_tavg-u-hxy-u:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siconc_d}, {freq: mon, model_var: siconc}]
+    table: seaIce
+    units: '%'
+
+  siconca_tavg-u-hxy-u:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siconca_d}, {freq: mon, model_var: siconca}]
+    table: seaIce
+    units: '%'
+
+  sidconcdyn_tavg-u-hxy-sea:
+    dims: [time, nj, ni]
+    long_name: Dynamic Sea Ice Concentration Change
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidconcdyn_d}, {freq: mon, model_var: sidconcdyn}]
+    table: seaIce
+    units: s-1
+
+  sidconcth_tavg-u-hxy-sea:
+    dims: [time, nj, ni]
+    long_name: Sea Ice Concentration Change due to Thickness Changes
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidconcth_d}, {freq: mon, model_var: sidconcth}]
+    table: seaIce
+    units: s-1
+
+  sidconcth_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidconcth_d}, {freq: mon, model_var: sidconcth}]
+    table: seaIce
+    units: kg m-2
+
+  sidivvel_tpt-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidivvel_d}, {freq: mon, model_var: sidivvel}]
+    table: seaIce
+    units: s-1
+
+  sidmassdyn_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmassdyn_d}, {freq: mon, model_var: sidmassdyn}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sidmassgrowthbot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmassgrowthbot_d}, {freq: mon, model_var: sidmassgrowthbot}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sidmassgrowthsi_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmassgrowthsi_d}, {freq: mon, model_var: sidmassgrowthsi}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sidmassgrowthwat_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmassgrowthwat_d}, {freq: mon, model_var: sidmassgrowthwat}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sidmassmeltbot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmassmeltbot_d}, {freq: mon, model_var: sidmassmeltbot}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sidmassmeltlat_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmassmeltlat_d}, {freq: mon, model_var: sidmassmeltlat}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sidmassmelttop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmassmelttop_d}, {freq: mon, model_var: sidmassmelttop}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sidmassth_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmassth_d}, {freq: mon, model_var: sidmassth}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sidmasstranx_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmasstranx_d}, {freq: mon, model_var: sidmasstranx}]
+    table: seaIce
+    units: kg s-1
+
+  sidmasstranx_tavg-u-hxy-u:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmasstranx_d}, {freq: mon, model_var: sidmasstranx}]
+    table: seaIce
+    units: kg s-1
+
+  sidmasstrany_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmasstrany_d}, {freq: mon, model_var: sidmasstrany}]
+    table: seaIce
+    units: kg s-1
+
+  sidmasstrany_tavg-u-hxy-u:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidmasstrany_d}, {freq: mon, model_var: sidmasstrany}]
+    table: seaIce
+    units: kg s-1
+
+  sidragbot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidragbot_d}, {freq: mon, model_var: sidragbot}]
+    table: seaIce
+    units: '1'
+
+  sidragtop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sidragtop_d}, {freq: mon, model_var: sidragtop}]
+    table: seaIce
+    units: '1'
+
+  sieqthick_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sieqthick_d}, {freq: mon, model_var: sieqthick}]
+    table: seaIce
+    units: m
+
+  siextent_tavg-u-hm-u:
+    dims: [time]
+    sources: [{alias: siconc, freq: day, model_var: siconc_d}, {freq: mon, model_var: siconc},
+      model_var: tarea]
+    table: seaIce
+    units: m2
+    variants: [{formula: '(tarea.where(siconc > 15., 0.0)).where(siconc.coords[''TLAT'']
+          > 0).sum(dim=[''nj'', ''ni''])', long_name: Sea Ice Extent (Northern Hemisphere),
+        region: nh}, {formula: '(tarea.where(siconc > 15., 0.0)).where(siconc.coords[''TLAT'']
+          < 0).sum(dim=[''nj'', ''ni''])', long_name: Sea Ice Extent (Southern Hemisphere),
+        region: sh}]
+
+  sifb_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sifb_d}, {freq: mon, model_var: sifb}]
+    table: seaIce
+    units: m
+
+  siflcondbot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siflcondbot_d}, {freq: mon, model_var: siflcondbot}]
+    table: seaIce
+    units: W m-2
+
+  siflcondtop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siflcondtop_d}, {freq: mon, model_var: siflcondtop}]
+    table: seaIce
+    units: W m-2
+
+
+  siflfwbot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siflfwbot_d}, {freq: mon, model_var: siflfwbot}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  siflfwdrain_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siflfwdrain_d}, {freq: mon, model_var: siflfwdrain}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sifllattop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sifllattop_d}, {freq: mon, model_var: sifllattop}]
+    table: seaIce
+    units: W m-2
+
+  siflsensbot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siflsensbot_d}, {freq: mon, model_var: siflsensbot}]
+    table: seaIce
+    units: W m-2
+
+  siflsenstop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siflsenstop_d}, {freq: mon, model_var: siflsenstop}]
+    table: seaIce
+    units: W m-2
+
+  siflswdbot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siflswdbot_d}, {freq: mon, model_var: siflswdbot}]
+    table: seaIce
+    units: W m-2
+
+  siflswdtop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siflswdtop_d}, {freq: mon, model_var: siflswdtop}]
+    table: seaIce
+    units: W m-2
+
+  siflswutop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siflswutop_d}, {freq: mon, model_var: siflswutop}]
+    table: seaIce
+    units: m
+
+  siforcecoriolx_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siforcecoriolx_d}, {freq: mon, model_var: siforcecoriolx}]
+    table: seaIce
+    units: N m-2
+
+  siforcecorioly_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siforcecorioly_d}, {freq: mon, model_var: siforcecorioly}]
+    table: seaIce
+    units: N m-2
+
+  siforceintstrx_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siforceintstrx_d}, {freq: mon, model_var: siforceintstrx}]
+    table: seaIce
+    units: N m-2
+
+  siforceintstry_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siforceintstry_d}, {freq: mon, model_var: siforceintstry}]
+    table: seaIce
+    units: N m-2
+
+  siforcetiltx_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siforcetiltx_d}, {freq: mon, model_var: siforcetiltx}]
+    table: seaIce
+    units: N m-2
+
+  siforcetilty_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siforcetilty_d}, {freq: mon, model_var: siforcetilty}]
+    table: seaIce
+    units: N m-2
+
+
+  sigpp_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sigpp_d}, {freq: mon, model_var: sigpp}]
+    table: seaIce
+    units: m s-1
+
+
+  siitdconc_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sitdconc_d}, {freq: mon, model_var: sitdconc}]
+    table: seaIce
+    units: kg m-2
+
+  siitdsnconc_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sitdsnconc_d}, {freq: mon, model_var: sitdsnconc}]
+    table: seaIce
+    units: kg m-2
+
+  siitdsnthick_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siitdsnthick_d}, {freq: mon, model_var: siitdsnthick}]
+    table: seaIce
+    units: m
+
+  siitdthick_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siitdthick_d}, {freq: mon, model_var: siitdthick}]
+    table: seaIce
+    units: m
+
+  simass_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: simass_d}, {freq: mon, model_var: simass}]
+    table: seaIce
+    units: kg m-2
+
+  simassacrossline_tavg-u-ht-u:
+    dims: [time, latitude]
+    long_name: Sea Ice Mass Across Line
+    regrid_method: conservative
+    sources: [{freq: day, model_var: simassacrossline_d}, {freq: mon, model_var: simassacrossline}]
+    table: seaIce
+    units: kg m-2
+
+  simpconc_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: simpconc_d}, {freq: mon, model_var: simpconc}]
+    table: seaIce
+    units: '%'
+
+  simpeffconc_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: simpeffconc_d}, {freq: mon, model_var: simpeffconc}]
+    table: seaIce
+    units: '%'
+
+  simprefrozen_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: simprefrozen_d}, {freq: mon, model_var: simprefrozen}]
+    table: seaIce
+    units: m
+
+  simprefrozen_tavg-u-hxy-simp:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: simprefrozen_d}, {freq: mon, model_var: simprefrozen}]
+    table: seaIce
+    units: m
+
+  simpthick_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: simpthick_d}, {freq: mon, model_var: simpthick}]
+    table: seaIce
+    units: m
+
+  simpthick_tavg-u-hxy-simp:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: simpthick_d}, {freq: mon, model_var: simpthick}]
+    table: seaIce
+    units: m
+
+  sino3_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sino3_d}, {freq: mon, model_var: sino3}]
+    table: seaIce
+    units: kg m-2
+
+  sipr_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sipr_d}, {freq: mon, model_var: sipr}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sirdgconc_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sirdgconc_d}, {freq: mon, model_var: sirdgconc}]
+    table: seaIce
+    units: '%'
+
+  sirdgthick_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sirdgthick_d}, {freq: mon, model_var: sirdgthick}]
+    table: seaIce
+    units: m
+
+  sisali_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisali_d}, {freq: mon, model_var: sisali}]
+    table: seaIce
+    units: 1e-3
+
+  sisaltmass_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisaltmass_d}, {freq: mon, model_var: sisaltmass}]
+    table: seaIce
+    units: kg m-2
+
+  sishearvel_tpt-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sishearvel_d}, {freq: mon, model_var: sishearvel}]
+    table: seaIce
+    units: m s-1
+
+  sisi_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisi_d}, {freq: mon, model_var: sisi}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sisndmassdyn_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisndmassdyn_d}, {freq: mon, model_var: sisndmassdyn}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sisndmassmelt_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisndmassmelt_d}, {freq: mon, model_var: sisndmassmelt}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sisndmasssi_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisndmasssi_d}, {freq: mon, model_var: sisndmasssi}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sisndmasssnf_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisndmasssnf_d}, {freq: mon, model_var: sisndmasssnf}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sisndmasssubl_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisndmasssubl_d}, {freq: mon, model_var: sisndmasssubl}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sisndmasswind_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisndmasswind_d}, {freq: mon, model_var: sisndmasswind}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sisnhc_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisnhc_d}, {freq: mon, model_var: sisnhc}]
+    table: seaIce
+    units: J m-2
+
+  sisnmass_tavg-u-hm-si:
+    dims: [time]
+    sources: [{alias: sisnmass, freq: day, model_var: sisnmass_d}, {freq: mon, model_var: sisnmass},
+      model_var: tarea]
+    table: seaIce
+    units: kg
+    variants: [{formula: '(sisnmass * tarea).where(sisnmass.coords[''TLAT''] > 0).sum(dim=[''nj'',
+          ''ni''])', long_name: Sea Ice Snow Mass (Northern Hemisphere), region: nh},
+      {formula: '(sisnmass * tarea).where(sisnmass.coords[''TLAT''] < 0).sum(dim=[''nj'',
+          ''ni''])', long_name: Sea Ice Snow Mass (Southern Hemisphere), region: sh}]
+
+  sisnmassacrossline_tavg-u-ht-u:
+    dims: [time, latitude]
+    long_name: Sea Ice Mass Across Line
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisnmassacrossline_d}, {freq: mon, model_var: sisnmassacrossline}]
+    table: seaIce
+    units: kg m-2 s-1
+
+  sisnthick_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sisnthick_d}, {freq: mon, model_var: sisnthick}]
+    table: seaIce
+    units: m
+
+  sispeed_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sispeed_d}, {freq: mon, model_var: sispeed}]
+    table: seaIce
+    units: m s-1
+
+  sistressave_tpt-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sistressave_d}, {freq: mon, model_var: sistressave}]
+    table: seaIce
+    units: N m-2
+
+  sistressmax_tpt-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sistressmax_d}, {freq: mon, model_var: sistressmax}]
+    table: seaIce
+    units: N m-2
+
+  sistrxdtop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sistrxdtop_d}, {freq: mon, model_var: sistrxdtop}]
+    table: seaIce
+    units: N m-2
+
+  sistrxubot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sistrxubot_d}, {freq: mon, model_var: sistrxubot}]
+    table: seaIce
+    units: N m-2
+
+  sistrydtop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sistrydtop_d}, {freq: mon, model_var: sistrydtop}]
+    table: seaIce
+    units: N m-2
+
+  sistryubot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    positive: down
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sistryubot_d}, {freq: mon, model_var: sistryubot}]
+    table: seaIce
+    units: N m-2
+
+  sitempbot_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sitempbot_d}, {freq: mon, model_var: sitempbot}]
+    table: seaIce
+    units: K
+
+  sitempsnic_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sitempsnic_d}, {freq: mon, model_var: sitempsnic}]
+    table: seaIce
+    units: K
+
+  sitemptop_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sitemptop_d}, {freq: mon, model_var: sitemptop}]
+    table: seaIce
+    units: K
+
+  sithick_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sithick_d}, {freq: mon, model_var: sithick}]
+    table: seaIce
+    units: m
+
+  sithick_tavg-u-hxy-sir:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sithick_d}, {freq: mon, model_var: sithick}]
+    table: seaIce
+    units: m
+
+  sitimefrac_tavg-u-hxy-sea:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sitimefrac_d}, {freq: mon, model_var: sitimefrac}]
+    table: seaIce
+    units: '1'
+
+  siu_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siu_d}, {freq: mon, model_var: siu}]
+    table: seaIce
+    units: m s-1
+
+  siv_tavg-u-hxy-ifs:
+    dims: [time, latitude, longitude]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siv_d}, {freq: mon, model_var: siv}]
+    table: seaIce
+    units: m s-1
+
+  siv_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: siv_d}, {freq: mon, model_var: siv}]
+    table: seaIce
+    units: m s-1
+
+  sivol_tavg-u-hm-u:
+    dims: [time]
+    sources: [{alias: sivol, freq: day, model_var: sivol_d}, {freq: mon, model_var: sivol},
+      model_var: tarea]
+    table: seaIce
+    units: 1e3 km^3
+    variants: [{formula: '(sivol * tarea).where(sivol.coords[''TLAT''] > 0).sum(dim=[''nj'',
+          ''ni''])', long_name: Sea Ice Volume (Northern Hemisphere), region: nh},
+      {formula: '(sivol * tarea).where(sivol.coords[''TLAT''] < 0).sum(dim=[''nj'',
+          ''ni''])', long_name: Sea Ice Volume (Southern Hemisphere), region: sh}]
+
+  sivol_tavg-u-hxy-si:
+    dims: [time, nj, ni]
+    regrid_method: conservative
+    sources: [{freq: day, model_var: sivol_d}, {freq: mon, model_var: sivol}]
+    table: seaIce
+    units: m3 m-3
+

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -116,7 +116,6 @@ INCLUDE_PATTERN_MAP = {
             "day": ["clm2.h1a"],
             "3hr": ["clm2.h2a"],
             "yr": ["clm2.h3a"],
-
         },
     },
 }

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -106,13 +106,17 @@ INCLUDE_PATTERN_MAP = {
     },
     "noresm": {
         "atmos": {
-            "mon": ["cam.h0"],
-            "day": ["cam.h1"],
+            "mon": ["cam.h0a"],
+            "day": ["cam.h1a"],
             "6hr": ["cam.h2a"],
-            "3hr": ["cam.h3a"],
+            "3hr": ["cam.h4a"],
         },
         "land": {
             "mon": ["clm2.h0a"],
+            "day": ["clm2.h1a"],
+            "3hr": ["clm2.h2a"],
+            "yr": ["clm2.h3a"],
+
         },
     },
 }

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -117,6 +117,10 @@ INCLUDE_PATTERN_MAP = {
             "3hr": ["clm2.h2a"],
             "yr": ["clm2.h3a"],
         },
+        "seaIce": {
+            "mon": ["cice.h."],
+            "day": ["cice.h1."],
+        },
     },
 }
 

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -239,6 +239,11 @@ def parse_args():
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         help="log output level",
     )
+    parser.add_argument(
+        "--custom-yaml",
+        default=False,
+        help="Path to custom YAML mapping file (optional, overrides default packaged YAML)",
+    )
 
     args = parser.parse_args()
     return args
@@ -369,7 +374,7 @@ def process_one_var(
                 results.append(
                     (str(varname), "analyzed native mom6 grid (realize applied)")
                 )
-            elif model == "cesm" and realm == "seaIce" and len(dims) == 1:
+            elif realm == "seaIce" and len(dims) == 1:
                 logger.info(
                     f"Preparing seaIce field variants via realize_all for {varname}"
                 )
@@ -714,7 +719,10 @@ def main():
             glob_pattern = "*.nc"
 
         # Load and evaluate the CMIP mapping YAML file (cesm_to_cmip7.yaml or noresm_to_cmip7.yaml)
-        if model == "noresm":
+        if custom_yaml := args.custom_yaml:
+            logger.info(f"Using custom YAML mapping file: {custom_yaml}")
+            mapping = Mapping.from_yaml(custom_yaml)
+        elif model == "noresm":
             mapping = Mapping.from_packaged_default(filename="noresm_to_cmip7.yaml")
         else:
             mapping = Mapping.from_packaged_default()

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -544,7 +544,6 @@ def _build_entry(row, config):
     if "sources" in entry and (scale_str or freq_str or alias_str):
         sources = entry["sources"]
         n = len(sources)
-
         scales = _split_positional(scale_str or "", n)
         freqs = _split_positional(freq_str or "", n)
         aliases = _split_positional(alias_str or "", n)

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -541,7 +541,11 @@ def _build_entry(row, config):
     scale_str = entry.pop("_scale", None)
     freq_str = entry.pop("_freq", None)
     alias_str = entry.pop("_alias", None)
-    if "sources" in entry and (scale_str or freq_str or alias_str):
+    if (
+        "sources" in entry
+        and (scale_str or freq_str or alias_str)
+        and entry.get("table") == "seaIce"
+    ):
         sources = entry["sources"]
         n = len(sources)
         scales = _split_positional(scale_str or "", n)
@@ -554,6 +558,7 @@ def _build_entry(row, config):
                     src["scale"] = float(scales[i])
                 except ValueError:
                     pass
+
             if freqs[i]:
                 src["freq"] = freqs[i]
             if aliases[i]:
@@ -612,12 +617,15 @@ def read_csv(filepath, config):
             # Multiple rows → variants variable.
             # Base fields come from the first row (they are identical across rows).
             base = {k: v for k, v in entries[0].items() if k not in _VARIANT_FIELDS}
-            variants = []
-            for e in entries:
-                variant = {k: e[k] for k in _VARIANT_FIELDS if k in e}
-                variants.append(variant)
-            base["variants"] = variants
-            data[name] = base
+            if entries[0]["table"] == "seaIce":
+                variants = []
+                for e in entries:
+
+                    variant = {k: e[k] for k in _VARIANT_FIELDS if k in e}
+                    variants.append(variant)
+
+                base["variants"] = variants
+                data[name] = base
 
     return {
         "dataset_overrides": config["dataset_overrides"],

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -544,9 +544,11 @@ def _build_entry(row, config):
     if "sources" in entry and (scale_str or freq_str or alias_str):
         sources = entry["sources"]
         n = len(sources)
+
         scales = _split_positional(scale_str or "", n)
         freqs = _split_positional(freq_str or "", n)
         aliases = _split_positional(alias_str or "", n)
+
         for i, src in enumerate(sources):
             if scales[i]:
                 try:
@@ -588,10 +590,8 @@ def read_csv(filepath, config):
     with open(filepath, "r", newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            # print(row)
             if not should_keep(row, config):
                 continue
-            print("keeping row")
             name = row[key_col].strip()
             if not name:
                 continue

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -62,7 +62,6 @@ MODEL_CONFIGS = {
             "Units (from Physical Parameter)": "units",
             "Dimensions": "dims",
             "NorESM3 name (dependency)": "_source_expr",
-            "CMIP7 Freq.": "_freq",
         },
         "realm_column": "Modelling Realm - Primary",
         "keep_realms": ["atmos", "land"],

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -569,9 +569,6 @@ def _build_entry(row, config):
         entry["levels"] = levels
     elif plev_name:
         entry["levels"] = {"name": plev_name, "units": "Pa"}
-        if plev_name == "plev39" and entry.get("sources"):
-            src_var = entry["sources"][0]["model_var"]
-            entry["formula"] = f'zonal_mean_on_pressure_grid("{src_var}")'
     elif "dims" in entry and "lev" in entry["dims"]:
         # Fallback for models without explicit levels columns (e.g., NorESM).
         entry["levels"] = {
@@ -675,10 +672,6 @@ def read_csv(filepath, config):
                 data[name] = base
             else:
                 # For atmos/land: no variants, no freq — just use first entry's base fields.
-                # formula is in _VARIANT_FIELDS so restore plev39-generated formulas explicitly.
-                formula = entries[0].get("formula", "")
-                if formula.startswith("zonal_mean_on_pressure_grid"):
-                    base["formula"] = formula
                 data[name] = base
 
     return {

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -485,6 +485,20 @@ def _build_entry(row, config):
             else:
                 dims = clean_strings(value.split(","), normalize)
             entry["dims"] = dims
+            plev_dim = next(
+                (d for d in entry["dims"] if re.match(r"^plev\d", d)), None
+            )
+            if plev_dim:
+                _DIM_ORDER = ["time", "plev", "lat", "lon"]
+                entry["dims"] = [
+                    "plev" if d == plev_dim else d for d in entry["dims"]
+                ]
+                entry["dims"].sort(
+                    key=lambda d: _DIM_ORDER.index(d)
+                    if d in _DIM_ORDER
+                    else len(_DIM_ORDER)
+                )
+                entry["_plev_name"] = plev_dim
         elif yaml_key == "units":
             entry["units"] = fix_number_norwegian_format(value)
         elif yaml_key == "_source_expr":
@@ -517,6 +531,7 @@ def _build_entry(row, config):
     levels_units = entry.pop("_levels_units", None)
     levels_src_axis_name = entry.pop("_levels_src_axis_name", None)
     levels_src_axis_bnds = entry.pop("_levels_src_axis_bnds", None)
+    plev_name = entry.pop("_plev_name", None)
 
     if levels_name:
         levels = {"name": levels_name}
@@ -527,6 +542,8 @@ def _build_entry(row, config):
         if levels_src_axis_bnds:
             levels["src_axis_bnds"] = levels_src_axis_bnds
         entry["levels"] = levels
+    elif plev_name:
+        entry["levels"] = {"name": plev_name, "units": "Pa"}
     elif "dims" in entry and "lev" in entry["dims"]:
         # Fallback for models without explicit levels columns (e.g., NorESM).
         entry["levels"] = {

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -675,6 +675,10 @@ def read_csv(filepath, config):
                 data[name] = base
             else:
                 # For atmos/land: no variants, no freq — just use first entry's base fields.
+                # formula is in _VARIANT_FIELDS so restore plev39-generated formulas explicitly.
+                formula = entries[0].get("formula", "")
+                if formula.startswith("zonal_mean_on_pressure_grid"):
+                    base["formula"] = formula
                 data[name] = base
 
     return {

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -569,6 +569,9 @@ def _build_entry(row, config):
         entry["levels"] = levels
     elif plev_name:
         entry["levels"] = {"name": plev_name, "units": "Pa"}
+        if plev_name == "plev39" and entry.get("sources"):
+            src_var = entry["sources"][0]["model_var"]
+            entry["formula"] = f'zonal_mean_on_pressure_grid("{src_var}")'
     elif "dims" in entry and "lev" in entry["dims"]:
         # Fallback for models without explicit levels columns (e.g., NorESM).
         entry["levels"] = {

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -6,6 +6,33 @@ import sys
 import argparse
 from typing import Optional
 
+# ── NorESM positive attribute overrides ──────────────────────────────────────
+# Maps branded variable name → "up" or "down".
+# Entries here are written as `positive: <value>` in the NorESM output YAML.
+NORESM_POSITIVE_OVERRIDES: dict[str, str] = {
+    # "<branded_variable_name>": "up",
+    # "<branded_variable_name>": "down",
+    "hfls_tavg-u-hxy-u": "down",
+    "hfss_tavg-u-hxy-u": "down",
+    "rlds_tavg-u-hxy-u": "down",
+    "rls_tavg-u-hxy-u": "down",
+    "rlut_tavg-u-hxy-u": "down",
+    "rlutcs_tavg-u-hxy-u": "down",
+    "rlut_tavg-u-hxy-u": "down",
+    "rlutcs_tavg-u-hxy-u": "down",
+    "rsds_tavg-u-hxy-u": "down",
+    "rsdscs_tavg-u-hxy-u": "down",
+    "rsdt_tavg-u-hxy-u": "down",
+    "rss_tavg-u-hxy-u": "down",
+    "rsuscs_tavg-u-hxy-u": "down",
+    "rsutcs_tavg-u-hxy-u": "down",
+    "rsut_tavg-u-hxy-u": "down",
+    "rsutcs_tavg-u-hxy-u": "down",
+    "rtmt_tavg-u-hxy-u": "down",
+    "tauu_tavg-u-hxy-u": "down",
+    "tauv_tavg-u-hxy-u": "down"
+}
+
 # ── model configurations ─────────────────────────────────────────────────────
 # Each config defines how to read a model-specific CSV and what metadata to write.
 #
@@ -57,6 +84,7 @@ MODEL_CONFIGS = {
             "_tminavg-",
             "_tminavg-",
         ],
+        "positive_overrides": NORESM_POSITIVE_OVERRIDES,
     },
     "cesm": {
         "default_input": "cesm_data.csv",
@@ -616,6 +644,9 @@ def read_csv(filepath, config):
             if not name:
                 continue
             entry = _build_entry(row, config)
+            positive = config.get("positive_overrides", {}).get(name)
+            if positive:
+                entry["positive"] = positive
 
             all_entries.append((name, entry))
 

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -34,7 +34,6 @@ MODEL_CONFIGS = {
         "key_column": "Branded Variable Name",
         "column_map": {
             "Modelling Realm - Primary": "table",
-            "CMIP6 Compound Name": "long_name",
             "Description": "description",
             "Units (from Physical Parameter)": "units",
             "Dimensions": "dims",

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -27,7 +27,7 @@ NORESM_POSITIVE_OVERRIDES: dict[str, str] = {
     "rsut_tavg-u-hxy-u": "down",
     "rtmt_tavg-u-hxy-u": "down",
     "tauu_tavg-u-hxy-u": "down",
-    "tauv_tavg-u-hxy-u": "down"
+    "tauv_tavg-u-hxy-u": "down",
 }
 
 # ── model configurations ─────────────────────────────────────────────────────
@@ -100,9 +100,8 @@ MODEL_CONFIGS = {
             "Dimensions": "dims",
             "CESM Variable Name": "_source_expr",
             # "Formula" overrides _source_expr when present (round-trip format).
-            # "Scale", "Freq", "Alias" are merged into sources in post-processing.
+            # "Freq", "Alias" are merged into sources in post-processing.
             "Formula": "_formula",
-            "Scale": "_scale",
             "Freq": "_freq",
             "Alias": "_alias",
             "Cell Methods": "cell_methods",
@@ -509,18 +508,14 @@ def _build_entry(row, config):
             else:
                 dims = clean_strings(value.split(","), normalize)
             entry["dims"] = dims
-            plev_dim = next(
-                (d for d in entry["dims"] if re.match(r"^plev\d", d)), None
-            )
+            plev_dim = next((d for d in entry["dims"] if re.match(r"^plev\d", d)), None)
             if plev_dim:
                 _DIM_ORDER = ["time", "plev", "lat", "lon"]
-                entry["dims"] = [
-                    "plev" if d == plev_dim else d for d in entry["dims"]
-                ]
+                entry["dims"] = ["plev" if d == plev_dim else d for d in entry["dims"]]
                 entry["dims"].sort(
-                    key=lambda d: _DIM_ORDER.index(d)
-                    if d in _DIM_ORDER
-                    else len(_DIM_ORDER)
+                    key=lambda d: (
+                        _DIM_ORDER.index(d) if d in _DIM_ORDER else len(_DIM_ORDER)
+                    )
                 )
                 entry["_plev_name"] = plev_dim
         elif yaml_key == "units":
@@ -529,7 +524,7 @@ def _build_entry(row, config):
             names = _parse_csv_identifiers(value)
             if names is not None:
                 # New format: comma-separated plain variable names.
-                # Scale/Freq/Alias will be merged in post-processing.
+                # Freq/Alias will be merged in post-processing.
                 entry["sources"] = [{"model_var": n} for n in names]
             else:
                 result = analyse_expression(value)
@@ -539,7 +534,7 @@ def _build_entry(row, config):
                 else:
                     entry["sources"] = result["variables"]
 
-        elif yaml_key in ("_scale", "_freq", "_alias"):
+        elif yaml_key in ("_freq", "_alias"):
             entry[yaml_key] = value
 
         else:
@@ -577,28 +572,20 @@ def _build_entry(row, config):
             "src_axis_bnds": "ilev",
         }
 
-    # Merge Scale/Freq/Alias columns into the per-source dicts.
-    scale_str = entry.pop("_scale", None)
+    # Merge Freq/Alias columns into the per-source dicts.
     freq_str = entry.pop("_freq", None)
     alias_str = entry.pop("_alias", None)
     if (
         "sources" in entry
-        and (scale_str or freq_str or alias_str)
+        and (freq_str or alias_str)
         and entry.get("table") == "seaIce"
     ):
         sources = entry["sources"]
         n = len(sources)
-        scales = _split_positional(scale_str or "", n)
         freqs = _split_positional(freq_str or "", n)
         aliases = _split_positional(alias_str or "", n)
 
         for i, src in enumerate(sources):
-            if scales[i]:
-                try:
-                    src["scale"] = float(scales[i])
-                except ValueError:
-                    pass
-
             if freqs[i]:
                 src["freq"] = freqs[i]
             if aliases[i]:
@@ -690,7 +677,7 @@ def write_yaml(data, filepath):
     for line in lines:
         if "{model_var:" in line:
             # Only reformat single-key source dicts: {model_var: VAR} → model_var: VAR
-            # Leave multi-key dicts (e.g. {model_var: VAR, scale: -1.0}) untouched.
+            # Leave multi-key dicts (e.g. {model_var: VAR, freq: mon}) untouched.
             line = re.sub(r"\{model_var: (\w+)\}", r"model_var: \1", line)
         if "FATES_FRAC" in line:
             line = line.replace("FATES_FRAC", "FATES_FRACTION")

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -18,8 +18,6 @@ NORESM_POSITIVE_OVERRIDES: dict[str, str] = {
     "rls_tavg-u-hxy-u": "down",
     "rlut_tavg-u-hxy-u": "down",
     "rlutcs_tavg-u-hxy-u": "down",
-    "rlut_tavg-u-hxy-u": "down",
-    "rlutcs_tavg-u-hxy-u": "down",
     "rsds_tavg-u-hxy-u": "down",
     "rsdscs_tavg-u-hxy-u": "down",
     "rsdt_tavg-u-hxy-u": "down",
@@ -27,7 +25,6 @@ NORESM_POSITIVE_OVERRIDES: dict[str, str] = {
     "rsuscs_tavg-u-hxy-u": "down",
     "rsutcs_tavg-u-hxy-u": "down",
     "rsut_tavg-u-hxy-u": "down",
-    "rsutcs_tavg-u-hxy-u": "down",
     "rtmt_tavg-u-hxy-u": "down",
     "tauu_tavg-u-hxy-u": "down",
     "tauv_tavg-u-hxy-u": "down"

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -626,6 +626,9 @@ def read_csv(filepath, config):
 
                 base["variants"] = variants
                 data[name] = base
+            else:
+                # For atmos/land: no variants, no freq — just use first entry's base fields.
+                data[name] = base
 
     return {
         "dataset_overrides": config["dataset_overrides"],

--- a/scripts/yaml_to_csv.py
+++ b/scripts/yaml_to_csv.py
@@ -28,7 +28,6 @@ CESM_COLUMNS = [
     "Dimensions",
     "CESM Variable Name",  # comma-separated source variable name(s); used by convert_csv_to_yaml.py as skip filter
     "Formula",  # the formula string, present only when original had one
-    "Scale",  # comma-separated scale factors, positionally aligned with CESM Variable Name
     "Freq",  # comma-separated sampling frequencies, positionally aligned with CESM Variable Name
     "Alias",  # comma-separated source aliases, positionally aligned with CESM Variable Name
     "Cell Methods",
@@ -45,15 +44,15 @@ CESM_COLUMNS = [
 def sources_to_names(sources: list[dict]) -> str:
     """Return a comma-separated list of model variable names from *sources*.
 
-    Only the ``model_var`` field is included; scale factors and other
-    sub-fields are intentionally omitted so the result is a plain list of
+    Only the ``model_var`` field is included;
+    sub-fields that are intentionally omitted so the result is a plain list of
     CESM variable names suitable for the ``CESM Variable Name`` CSV column.
 
     >>> sources_to_names([{"model_var": "TREFHT"}])
     'TREFHT'
     >>> sources_to_names([{"model_var": "PRECC"}, {"model_var": "PRECL"}])
     'PRECC, PRECL'
-    >>> sources_to_names([{"model_var": "QFLX", "scale": -1.0}])
+    >>> sources_to_names([{"model_var": "sialgc", "freq": "day"}])
     'QFLX'
     >>> sources_to_names([])
     ''
@@ -63,32 +62,30 @@ def sources_to_names(sources: list[dict]) -> str:
     )
 
 
-def sources_to_scale_freq_alias(sources: list[dict]) -> tuple[str, str, str]:
-    """Return (scale_str, freq_str, alias_str) for the Scale/Freq/Alias CSV columns.
+def sources_to_freq_alias(sources: list[dict]) -> tuple[str, str, str]:
+    """Return (freq_str, alias_str) for the Freq/Alias CSV columns.
 
     Each returned string is a comma-separated list positionally aligned with
     the ``CESM Variable Name`` column.  If all sources lack a given attribute
     the corresponding string is empty.
 
-    >>> sources_to_scale_freq_alias([{"model_var": "TREFHT"}])
-    ('', '', '')
-    >>> sources_to_scale_freq_alias([{"model_var": "QFLX", "scale": -1.0}])
-    ('-1.0', '', '')
-    >>> sources_to_scale_freq_alias([{"model_var": "siconc", "freq": "day"}, {"model_var": "tarea"}])
-    ('', 'day, ', '')
-    >>> sources_to_scale_freq_alias([{"model_var": "A", "scale": 0.001, "freq": "day", "alias": "a"}, {"model_var": "B", "scale": 0.001}])
-    ('0.001, 0.001', 'day, ', 'a, ')
-    >>> sources_to_scale_freq_alias([])
+    >>> sources_to_freq_alias([{"model_var": "TREFHT"}])
+    ('', '')
+    >>> sources_to_freq_alias([{"model_var": "siconc", "freq": "day"}, {"model_var": "tarea"}])
+    ( 'day, ', '')
+    >>> sources_to_freq_alias([{"model_var": "A", "freq": "day", "alias": "a"}, {"model_var": "B"}])
+    ('day, ', 'a, ')
+    >>> sources_to_freq_alias([])
     ('', '', '')
     """
     if not sources:
-        return ("", "", "")
+        return ("", "")
 
     def _col(attr):
         vals = [str(src.get(attr, "")) for src in sources]
         return ", ".join(vals) if any(v for v in vals) else ""
 
-    return (_col("scale"), _col("freq"), _col("alias"))
+    return (_col("freq"), _col("alias"))
 
 
 def variable_to_rows(name: str, var: dict) -> list:
@@ -97,7 +94,7 @@ def variable_to_rows(name: str, var: dict) -> list:
     Variables without ``variants`` produce a single row.  Variables with
     ``variants`` produce one row per variant, each carrying the variant's
     ``formula``, ``long_name``, and ``region``.  Per-source attributes
-    (``scale``, ``freq``, ``alias``) are written to the ``Scale``, ``Freq``,
+    (``freq``, ``alias``) are written to the ``Freq``,
     and ``Alias`` columns as comma-separated values positionally aligned with
     ``CESM Variable Name``.
 
@@ -110,8 +107,6 @@ def variable_to_rows(name: str, var: dict) -> list:
     'TREFHT'
     >>> rows[0]["Formula"]
     ''
-    >>> rows[0]["Scale"]
-    ''
     >>> rows[0]["Dimensions"]
     '["time", "lat", "lon"]'
     >>> rows[0]["Region"]
@@ -122,13 +117,6 @@ def variable_to_rows(name: str, var: dict) -> list:
     'PRECC + PRECL'
     >>> rows2[0]["CESM Variable Name"]
     'PRECC, PRECL'
-
-    >>> var_with_scale = {"table": "atmos", "units": "kg m-2 s-1", "dims": ["time", "lat", "lon"], "sources": [{"model_var": "QFLX", "scale": -1.0}]}
-    >>> rows_scale = variable_to_rows("evspsbl", var_with_scale)
-    >>> rows_scale[0]["Formula"]
-    ''
-    >>> rows_scale[0]["Scale"]
-    '-1.0'
 
     >>> var_with_variants = {"table": "seaIce", "units": "m2", "dims": ["time"], "sources": [{"model_var": "siconc", "freq": "day"}, {"model_var": "tarea"}], "variants": [{"long_name": "NH", "region": "nh", "formula": "siconc.where(lat>0)"}, {"long_name": "SH", "region": "sh", "formula": "siconc.where(lat<0)"}]}
     >>> rows3 = variable_to_rows("siarea_tavg-u-hm-u", var_with_variants)
@@ -156,7 +144,7 @@ def variable_to_rows(name: str, var: dict) -> list:
     # Use JSON so that list-of-lists dims round-trip correctly.
     dims_str = json.dumps(dims)
 
-    scale_str, freq_str, alias_str = sources_to_scale_freq_alias(sources)
+    freq_str, alias_str = sources_to_freq_alias(sources)
 
     base = {
         "CMIP Variable Name": name,
@@ -167,7 +155,6 @@ def variable_to_rows(name: str, var: dict) -> list:
         "Cell Methods": var.get("cell_methods", ""),
         "Regrid Method": var.get("regrid_method", ""),
         "Positive": var.get("positive", ""),
-        "Scale": scale_str,
         "Freq": freq_str,
         "Alias": alias_str,
         "Levels Name": levels.get("name", ""),

--- a/src/cmip7_prep/mapping_compat.py
+++ b/src/cmip7_prep/mapping_compat.py
@@ -56,7 +56,6 @@ import logging
 import numpy as np
 import xarray as xr
 import yaml  # runtime dep
-from cmip7_prep.regrid import zonal_mean_on_pressure_grid as _zonal_mean_on_pressure_grid
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -174,7 +173,7 @@ class VarConfig:
         return {k: v for k, v in d.items() if v is not None}
 
 
-def _safe_eval(expr: str, local_names: Dict[str, Any], ds: Optional[xr.Dataset] = None) -> Any:
+def _safe_eval(expr: str, local_names: Dict[str, Any]) -> Any:
     """Evaluate a formula string in a restricted namespace.
 
     Built-in Python names are blocked (``__builtins__`` is empty).  The
@@ -187,9 +186,6 @@ def _safe_eval(expr: str, local_names: Dict[str, Any], ds: Optional[xr.Dataset] 
       along a soil/vertical dimension, optionally capping the result.
     * ``sumoverpft(arr, pftlist, dimname)`` – sum a DataArray over a subset
       of PFT indices along a named dimension.
-    * ``zonal_mean_on_pressure_grid(var_name)`` – interpolate a model variable
-      to a pressure grid and compute the zonal mean; only available when *ds*
-      is provided.
 
     Parameters
     ----------
@@ -259,11 +255,6 @@ def _safe_eval(expr: str, local_names: Dict[str, Any], ds: Optional[xr.Dataset] 
             "sumoverpft": sumoverpft,
         }
     )
-
-    if ds is not None:
-        def zonal_mean_on_pressure_grid(var_name: str) -> xr.DataArray:
-            return _zonal_mean_on_pressure_grid(ds, var_name)
-        safe_locals["zonal_mean_on_pressure_grid"] = zonal_mean_on_pressure_grid
     # pylint: disable=eval-used
     return eval(expr, safe_globals, safe_locals)
 
@@ -680,7 +671,7 @@ def _realize_core(ds: xr.Dataset, vc: VarConfig) -> xr.DataArray:
                 vc.name,
                 model_vars,
             )
-            result = _safe_eval(vc.formula, da_dict, ds=ds)
+            result = _safe_eval(vc.formula, da_dict)
 
         except Exception as exc:
             raise ValueError(f"Error evaluating formula for {vc.name}: {exc}") from exc

--- a/src/cmip7_prep/mapping_compat.py
+++ b/src/cmip7_prep/mapping_compat.py
@@ -533,7 +533,6 @@ def _to_varconfig(
 
     # Only support CMIP7 'sources' key
     raw_from_sources: Optional[List[str]] = None
-    scale_from_sources = None
     formula = cfg.get("formula")
     source = None
 
@@ -548,8 +547,7 @@ def _to_varconfig(
             raw_from_sources.append(mv)
             alias = str(item.get("alias", mv))
             aliases[alias] = mv
-            if scale_from_sources is None and "scale" in item:
-                scale_from_sources = item["scale"]
+
         elif isinstance(item, str):
             raw_from_sources.append(item)
             aliases[item] = item
@@ -561,8 +559,6 @@ def _to_varconfig(
         aliases = {}
 
     unit_conversion = cfg.get("unit_conversion")
-    if scale_from_sources is not None:
-        unit_conversion = {"scale": scale_from_sources}
 
     vc = VarConfig(
         name=name,
@@ -686,37 +682,4 @@ def _realize_core(ds: xr.Dataset, vc: VarConfig) -> xr.DataArray:
 
     raise ValueError(
         f"Mapping for {vc.name} is incomplete: set 'source' or 'raw_variables' or 'formula'."
-    )
-
-
-def _apply_unit_conversion(da: xr.DataArray, rule: Any) -> xr.DataArray:
-    """Apply a unit conversion rule to a DataArray.
-
-    >>> import xarray as xr
-    >>> da = xr.DataArray([1.0, 2.0, 3.0])
-    >>> _apply_unit_conversion(da, {"scale": 2.0}).values.tolist()
-    [2.0, 4.0, 6.0]
-    >>> _apply_unit_conversion(da, {"offset": 10.0}).values.tolist()
-    [11.0, 12.0, 13.0]
-    >>> _apply_unit_conversion(da, "x * 2").values.tolist()
-    [2.0, 4.0, 6.0]
-    """
-    if isinstance(rule, str):
-        try:
-            out = _safe_eval(rule, {"x": da})
-        except Exception as exc:
-            raise ValueError(
-                f"Error evaluating unit_conversion expression: {exc}"
-            ) from exc
-        if not isinstance(out, xr.DataArray):
-            raise ValueError("unit_conversion expression did not return a DataArray")
-        return out
-
-    if isinstance(rule, dict):
-        scale = rule.get("scale", 1.0)
-        offset = rule.get("offset", 0.0)
-        return da * float(scale) + float(offset)
-
-    raise TypeError(
-        "unit_conversion must be a string expression or a dict with 'scale'/'offset'"
     )

--- a/src/cmip7_prep/mapping_compat.py
+++ b/src/cmip7_prep/mapping_compat.py
@@ -56,6 +56,7 @@ import logging
 import numpy as np
 import xarray as xr
 import yaml  # runtime dep
+from cmip7_prep.regrid import zonal_mean_on_pressure_grid as _zonal_mean_on_pressure_grid
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -173,7 +174,7 @@ class VarConfig:
         return {k: v for k, v in d.items() if v is not None}
 
 
-def _safe_eval(expr: str, local_names: Dict[str, Any]) -> Any:
+def _safe_eval(expr: str, local_names: Dict[str, Any], ds: Optional[xr.Dataset] = None) -> Any:
     """Evaluate a formula string in a restricted namespace.
 
     Built-in Python names are blocked (``__builtins__`` is empty).  The
@@ -186,6 +187,9 @@ def _safe_eval(expr: str, local_names: Dict[str, Any]) -> Any:
       along a soil/vertical dimension, optionally capping the result.
     * ``sumoverpft(arr, pftlist, dimname)`` – sum a DataArray over a subset
       of PFT indices along a named dimension.
+    * ``zonal_mean_on_pressure_grid(var_name)`` – interpolate a model variable
+      to a pressure grid and compute the zonal mean; only available when *ds*
+      is provided.
 
     Parameters
     ----------
@@ -255,6 +259,11 @@ def _safe_eval(expr: str, local_names: Dict[str, Any]) -> Any:
             "sumoverpft": sumoverpft,
         }
     )
+
+    if ds is not None:
+        def zonal_mean_on_pressure_grid(var_name: str) -> xr.DataArray:
+            return _zonal_mean_on_pressure_grid(ds, var_name)
+        safe_locals["zonal_mean_on_pressure_grid"] = zonal_mean_on_pressure_grid
     # pylint: disable=eval-used
     return eval(expr, safe_globals, safe_locals)
 
@@ -671,7 +680,7 @@ def _realize_core(ds: xr.Dataset, vc: VarConfig) -> xr.DataArray:
                 vc.name,
                 model_vars,
             )
-            result = _safe_eval(vc.formula, da_dict)
+            result = _safe_eval(vc.formula, da_dict, ds=ds)
 
         except Exception as exc:
             raise ValueError(f"Error evaluating formula for {vc.name}: {exc}") from exc

--- a/src/cmip7_prep/pipeline.py
+++ b/src/cmip7_prep/pipeline.py
@@ -328,4 +328,9 @@ def realize_regrid_prepare(
     if aux:
         ds_regr = ds_regr.merge(ds_native[aux], compat="override")
 
+    # 9) For plev39: take zonal mean over lon after regridding to lat/lon.
+    if lev_kind == "plev39" and "lon" in ds_regr[str(cmip_var)].dims:
+        logger.info("Applying zonal mean over lon for plev39 variable: %s", cmip_var)
+        ds_regr[str(cmip_var)] = ds_regr[str(cmip_var)].mean("lon")
+
     return ds_regr

--- a/src/cmip7_prep/unused_functions.py
+++ b/src/cmip7_prep/unused_functions.py
@@ -1,5 +1,7 @@
-import xarray as xr
+"""Utility functions for unit conversion and related transformations."""
 from typing import Any
+
+import xarray as xr
 
 from cmip7_prep.mapping_compat import _safe_eval
 

--- a/src/cmip7_prep/unused_functions.py
+++ b/src/cmip7_prep/unused_functions.py
@@ -1,0 +1,37 @@
+import xarray as xr
+from typing import Any
+
+from cmip7_prep.mapping_compat import _safe_eval
+
+
+def _apply_unit_conversion(da: xr.DataArray, rule: Any) -> xr.DataArray:
+    """Apply a unit conversion rule to a DataArray.
+
+    >>> import xarray as xr
+    >>> da = xr.DataArray([1.0, 2.0, 3.0])
+    >>> _apply_unit_conversion(da, {"scale": 2.0}).values.tolist()
+    [2.0, 4.0, 6.0]
+    >>> _apply_unit_conversion(da, {"offset": 10.0}).values.tolist()
+    [11.0, 12.0, 13.0]
+    >>> _apply_unit_conversion(da, "x * 2").values.tolist()
+    [2.0, 4.0, 6.0]
+    """
+    if isinstance(rule, str):
+        try:
+            out = _safe_eval(rule, {"x": da})
+        except Exception as exc:
+            raise ValueError(
+                f"Error evaluating unit_conversion expression: {exc}"
+            ) from exc
+        if not isinstance(out, xr.DataArray):
+            raise ValueError("unit_conversion expression did not return a DataArray")
+        return out
+
+    if isinstance(rule, dict):
+        scale = rule.get("scale", 1.0)
+        offset = rule.get("offset", 0.0)
+        return da * float(scale) + float(offset)
+
+    raise TypeError(
+        "unit_conversion must be a string expression or a dict with 'scale'/'offset'"
+    )

--- a/src/cmip7_prep/unused_functions.py
+++ b/src/cmip7_prep/unused_functions.py
@@ -1,4 +1,5 @@
 """Utility functions for unit conversion and related transformations."""
+
 from typing import Any
 
 import xarray as xr

--- a/tests/test_convert_csv_to_yaml.py
+++ b/tests/test_convert_csv_to_yaml.py
@@ -835,7 +835,7 @@ class TestReadCsvCESM:
         ]
         data = read_csv(_write_temp_csv(tmp_path, self.FIELDNAMES, rows), self.CFG)
         var = data["variables"]["evspsbl"]
-        assert var["sources"] == [{"model_var": "QFLX", "scale": -1.0}]
+        assert var["sources"] == [{"model_var": "QFLX"}]
 
     def test_freq_from_column(self, tmp_path):
         """Freq column is merged positionally into the sources list."""
@@ -878,25 +878,6 @@ class TestReadCsvCESM:
         assert sources[0] == {"model_var": "siconc_d", "freq": "day", "alias": "siconc"}
         assert sources[1] == {"model_var": "siconc", "freq": "mon"}
         assert sources[2] == {"model_var": "tarea"}
-
-    def test_scale_stored_as_float(self, tmp_path):
-        """Scale values are stored as floats, not strings."""
-        rows = [
-            self._row(
-                **{
-                    "CMIP Variable Name": "pr",
-                    "Table": "atmos",
-                    "Units": "kg m-2 s-1",
-                    "Dimensions": "time, lat, lon",
-                    "CESM Variable Name": "PRECT",
-                    "Scale": "1000.0",
-                }
-            )
-        ]
-        data = read_csv(_write_temp_csv(tmp_path, self.FIELDNAMES, rows), self.CFG)
-        scale = data["variables"]["pr"]["sources"][0]["scale"]
-        assert isinstance(scale, float)
-        assert scale == 1000.0
 
     def test_multi_source_formula(self, tmp_path):
         """Multiple sources in CESM Variable Name with a formula expression."""

--- a/tests/test_convert_csv_to_yaml.py
+++ b/tests/test_convert_csv_to_yaml.py
@@ -428,11 +428,10 @@ class TestReadCsvNorESM:
         assert "variables" in data
         var = data["variables"]["tas"]
         assert var["table"] == "atmos"
-        assert var["long_name"] == "Near-Surface Air Temperature"
+        assert "long_name" not in var
         assert var["units"] == "K"
-        assert var["sources"] == [{"model_var": "TREFHT", "freq": "mon"}]
+        assert var["sources"] == [{"model_var": "TREFHT"}]
         assert "formula" not in var
-        assert var["sources"][0]["freq"] == "mon"
 
     def test_math_formula_stored(self, tmp_path):
         """A math expression is stored as formula and sources are extracted."""

--- a/tests/test_mapping_compat_extra.py
+++ b/tests/test_mapping_compat_extra.py
@@ -9,7 +9,6 @@ import xarray as xr
 from cmip7_prep.mapping_compat import (
     Mapping,
     VarConfig,
-    _apply_unit_conversion,
 )
 
 _FORMULA_YAML = """
@@ -129,39 +128,3 @@ class TestMappingRealize:
         ds = xr.Dataset({"T": xr.DataArray([1.0, 2.0])})  # 'TS' missing
         with pytest.raises(KeyError, match="TS"):
             m.realize(ds, "tas")
-
-
-class TestApplyUnitConversion:
-    """Tests for _apply_unit_conversion dict and string-expression rules."""
-
-    # pylint: disable=too-few-public-methods
-
-    def test_dict_scale_only(self):
-        """scale-only dict multiplies each value by scale."""
-        da = xr.DataArray([1.0, 2.0, 3.0])
-        result = _apply_unit_conversion(da, {"scale": 2.0})
-        np.testing.assert_allclose(result.values, [2.0, 4.0, 6.0])
-
-    def test_dict_scale_and_offset(self):
-        """scale+offset dict applies linear transformation."""
-        da = xr.DataArray([0.0, 100.0])
-        result = _apply_unit_conversion(da, {"scale": 1.0, "offset": 273.15})
-        np.testing.assert_allclose(result.values, [273.15, 373.15])
-
-    def test_string_expression(self):
-        """String expression 'x * 1000.0' scales by 1000."""
-        da = xr.DataArray([1.0, 2.0, 3.0])
-        result = _apply_unit_conversion(da, "x * 1000.0")
-        np.testing.assert_allclose(result.values, [1000.0, 2000.0, 3000.0])
-
-    def test_unsupported_type_raises(self):
-        """Non-string, non-dict rule raises TypeError."""
-        da = xr.DataArray([1.0])
-        with pytest.raises(TypeError, match="unit_conversion"):
-            _apply_unit_conversion(da, 42)
-
-    def test_bad_string_expr_raises(self):
-        """Invalid expression string raises ValueError."""
-        da = xr.DataArray([1.0])
-        with pytest.raises(ValueError, match="unit_conversion"):
-            _apply_unit_conversion(da, "undefined_func(x)")

--- a/tests/test_unused_functions.py
+++ b/tests/test_unused_functions.py
@@ -1,0 +1,43 @@
+"""Tests for currently unused functions like _apply_unit_conversion."""
+
+import pytest
+import numpy as np
+import xarray as xr
+
+from cmip7_prep.unused_functions import _apply_unit_conversion
+
+
+class TestApplyUnitConversion:
+    """Tests for _apply_unit_conversion dict and string-expression rules."""
+
+    # pylint: disable=too-few-public-methods
+
+    def test_dict_scale_only(self):
+        """scale-only dict multiplies each value by scale."""
+        da = xr.DataArray([1.0, 2.0, 3.0])
+        result = _apply_unit_conversion(da, {"scale": 2.0})
+        np.testing.assert_allclose(result.values, [2.0, 4.0, 6.0])
+
+    def test_dict_scale_and_offset(self):
+        """scale+offset dict applies linear transformation."""
+        da = xr.DataArray([0.0, 100.0])
+        result = _apply_unit_conversion(da, {"scale": 1.0, "offset": 273.15})
+        np.testing.assert_allclose(result.values, [273.15, 373.15])
+
+    def test_string_expression(self):
+        """String expression 'x * 1000.0' scales by 1000."""
+        da = xr.DataArray([1.0, 2.0, 3.0])
+        result = _apply_unit_conversion(da, "x * 1000.0")
+        np.testing.assert_allclose(result.values, [1000.0, 2000.0, 3000.0])
+
+    def test_unsupported_type_raises(self):
+        """Non-string, non-dict rule raises TypeError."""
+        da = xr.DataArray([1.0])
+        with pytest.raises(TypeError, match="unit_conversion"):
+            _apply_unit_conversion(da, 42)
+
+    def test_bad_string_expr_raises(self):
+        """Invalid expression string raises ValueError."""
+        da = xr.DataArray([1.0])
+        with pytest.raises(ValueError, match="unit_conversion"):
+            _apply_unit_conversion(da, "undefined_func(x)")

--- a/tests/test_yaml_to_csv.py
+++ b/tests/test_yaml_to_csv.py
@@ -16,67 +16,50 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 # pylint: disable=wrong-import-position
 from yaml_to_csv import (
     CESM_COLUMNS,
-    sources_to_scale_freq_alias,
+    sources_to_freq_alias,
     variable_to_rows,
     yaml_to_csv,
 )
 
-# ── sources_to_scale_freq_alias ───────────────────────────────────────────────
+# ── sources_to_freq_alias ───────────────────────────────────────────────
 
 
-class TestSourcesToScaleFreqAlias:
-    """Tests for sources_to_scale_freq_alias()."""
+class TestSourcesToFreqAlias:
+    """Tests for sources_to_freq_alias()."""
 
     def test_empty(self):
         """Empty sources list returns three empty strings."""
-        assert sources_to_scale_freq_alias([]) == ("", "", "")
+        assert sources_to_freq_alias([]) == ("", "")
 
     def test_single_no_extras(self):
         """A single source with no extra attrs returns three empty strings."""
-        assert sources_to_scale_freq_alias([{"model_var": "TREFHT"}]) == ("", "", "")
-
-    def test_single_with_scale(self):
-        """A single source with scale is reflected in the Scale string."""
-        scale, freq, alias = sources_to_scale_freq_alias(
-            [{"model_var": "QFLX", "scale": -1.0}]
-        )
-        assert scale == "-1.0"
-        assert freq == ""
-        assert alias == ""
+        assert sources_to_freq_alias([{"model_var": "TREFHT"}]) == ("", "")
 
     def test_single_with_freq(self):
         """A single source with freq is reflected in the Freq string."""
-        scale, freq, alias = sources_to_scale_freq_alias(
-            [{"model_var": "siconc", "freq": "day"}]
-        )
-        assert scale == ""
+        freq, alias = sources_to_freq_alias([{"model_var": "siconc", "freq": "day"}])
         assert freq == "day"
         assert alias == ""
 
     def test_two_sources_first_has_freq(self):
         """Positional alignment: first source has freq, second does not."""
-        scale, freq, alias = sources_to_scale_freq_alias(
+        freq, alias = sources_to_freq_alias(
             [{"model_var": "siconc", "freq": "day"}, {"model_var": "tarea"}]
         )
-        assert scale == ""
         assert freq == "day, "
         assert alias == ""
 
     def test_two_sources_both_have_scale(self):
         """Both sources with identical scales."""
-        scale, freq, alias = sources_to_scale_freq_alias(
-            [{"model_var": "A", "scale": 0.001}, {"model_var": "B", "scale": 0.001}]
-        )
-        assert scale == "0.001, 0.001"
+        freq, alias = sources_to_freq_alias([{"model_var": "A"}, {"model_var": "B"}])
         assert freq == ""
         assert alias == ""
 
     def test_all_three_attrs(self):
         """A source with all three extra attrs populates all three columns."""
-        scale, freq, alias = sources_to_scale_freq_alias(
-            [{"model_var": "siconc_d", "scale": 1.0, "freq": "day", "alias": "siconc"}]
+        freq, alias = sources_to_freq_alias(
+            [{"model_var": "siconc_d", "freq": "day", "alias": "siconc"}]
         )
-        assert scale == "1.0"
         assert freq == "day"
         assert alias == "siconc"
 
@@ -87,8 +70,7 @@ class TestSourcesToScaleFreqAlias:
             {"model_var": "siconc", "freq": "mon"},
             {"model_var": "tarea"},
         ]
-        scale, freq, alias = sources_to_scale_freq_alias(sources)
-        assert scale == ""
+        freq, alias = sources_to_freq_alias(sources)
         assert freq == "day, mon, "
         assert alias == "siconc, , "
 
@@ -148,22 +130,6 @@ class TestVariableToRow:
         )[0]
         assert row["CESM Variable Name"] == "PRECC, PRECL"
 
-    def test_scale_excluded_from_cesm_variable_name(self):
-        """Scale factors are not included in CESM Variable Name — only the variable name."""
-        row = variable_to_rows(
-            "evspsbl",
-            {
-                "table": "atmos",
-                "units": "kg m-2 s-1",
-                "dims": ["time", "lat", "lon"],
-                "sources": [{"model_var": "QFLX", "scale": -1.0}],
-            },
-        )[0]
-        assert row["CESM Variable Name"] == "QFLX"
-        assert row["Scale"] == "-1.0"
-        assert row["Freq"] == ""
-        assert row["Alias"] == ""
-
     def test_freq_in_freq_column(self):
         """Freq attributes appear in the Freq column, aligned with CESM Variable Name."""
         row = variable_to_rows(
@@ -180,7 +146,6 @@ class TestVariableToRow:
         )[0]
         assert row["CESM Variable Name"] == "siconc, tarea"
         assert row["Freq"] == "day, "
-        assert row["Scale"] == ""
 
     def test_optional_fields_empty_when_absent(self):
         """Optional columns are empty strings when not present in the variable dict."""
@@ -263,6 +228,7 @@ class TestVariableToRow:
 
     def test_no_sources_or_formula_gives_empty(self):
         """A variable with neither sources nor formula gets an empty expression."""
+        print(variable_to_rows("mystery", {"table": "atmos", "units": "1"}))
         row = variable_to_rows("mystery", {"table": "atmos", "units": "1"})[0]
         assert row["CESM Variable Name"] == ""
 
@@ -413,27 +379,6 @@ class TestYamlToCsv:
         assert rows[0]["CESM Variable Name"] == "SOIL1C, SOIL2C, SOIL3C"
         assert rows[0]["Formula"] == "(SOIL1C + SOIL2C + SOIL3C)/1000.0"
 
-    def test_scale_in_scale_column(self, tmp_path):
-        """Scale factors appear in the Scale column, not in CESM Variable Name."""
-        ypath = _make_yaml(
-            tmp_path,
-            {
-                "evspsbl": {
-                    "table": "atmos",
-                    "units": "kg m-2 s-1",
-                    "dims": ["time", "lat", "lon"],
-                    "sources": [{"model_var": "QFLX", "scale": -1.0}],
-                }
-            },
-        )
-        cpath = str(tmp_path / "out.csv")
-        yaml_to_csv(ypath, cpath)
-        rows = _read_csv(cpath)
-        assert rows[0]["CESM Variable Name"] == "QFLX"
-        assert rows[0]["Scale"] == "-1.0"
-        assert rows[0]["Freq"] == ""
-        assert rows[0]["Alias"] == ""
-
     def test_optional_fields_empty_when_absent(self, tmp_path):
         """Optional columns are empty when not present in the YAML."""
         ypath = _make_yaml(
@@ -489,7 +434,7 @@ class TestYamlToCsv:
                 "table": "atmos",
                 "units": "kg m-2 s-1",
                 "dims": ["time", "lat", "lon"],
-                "sources": [{"model_var": "QFLX", "scale": -1.0}],
+                "sources": [{"model_var": "QFLX"}],
             },
         }
         ypath = _make_yaml(tmp_path, variables)
@@ -510,4 +455,4 @@ class TestYamlToCsv:
         assert "levels" in cl  # lev dim → levels block added
 
         evspsbl = result["variables"]["evspsbl"]
-        assert evspsbl["sources"] == [{"model_var": "QFLX", "scale": -1.0}]
+        assert evspsbl["sources"] == [{"model_var": "QFLX"}]


### PR DESCRIPTION
  PR Summary: feature/add_positive_to_noresm → main

  Changes to scripts/convert_csv_to_yaml.py

  Add positive attribute support for NorESM variables

  Introduces a top-level NORESM_POSITIVE_OVERRIDES dictionary that maps branded variable names to a positive value ("up" or "down"). The dictionary is wired into the NorESM model config and applied in read_csv so that matched variables
  get a positive: field written into the output YAML.

  The following 14 NorESM variables are marked positive: down — surface and TOA radiative fluxes, heat fluxes, and wind stresses that are defined as positive in the downward direction:

  For now only the atmos realm dictionalry has been added:
  hfls, hfss, rlds, rls, rlut, rlutcs, rsds, rsdscs, rsdt, rss, rsuscs, rsut, rsutcs, rtmt, tauu, tauv

  CESM is unaffected — it already reads positive directly from its CSV Positive column.


