### PR TITLE
seaIce support, NorESM tnx1v4 regridding and error handling improvements

### DIFF
--- a/data/noresm_to_cmip7_atmos.yaml
+++ b/data/noresm_to_cmip7_atmos.yaml
@@ -738,7 +738,7 @@ variables:
 
   tas_tmaxavg-h2m-hxy-u:
     description: monthly mean of the daily-maximum near-surface air temperature.
-    dims: [lon, lat, time4, height2m]
+    dims: [lon, lat, height2m]
     sources: [model_var: TREFMXAV]
     table: atmos
     units: K

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -64,8 +64,7 @@ _DATE_RE = re.compile(
 )
 
 # Path for cmor tables
-#TABLES_cesm = "/glade/derecho/scratch/jedwards/cmip7-prep/cmip7-cmor-tables/"
-TABLES_cesm = "/nird/datalake/NS9560K/mvertens/packages/cmip7-prep/cmip7-cmor-tables/"
+TABLES_cesm = "/glade/derecho/scratch/jedwards/cmip7-prep/cmip7-cmor-tables/"
 TABLES_noresm = "/nird/datalake/NS9560K/mvertens/packages/cmip7-prep/cmip7-cmor-tables/"
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -188,6 +187,7 @@ def parse_args():
             "ne16",
             "ne30",
             "tx2_3v2",
+            "regular",
         ],
         default="ne30",
         help="input_grid name (Default: ne30)",

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -491,7 +491,7 @@ def process_one_var(
                 cmor_items = [(ds_cmor, cfg)]
 
         except (FileNotFoundError, KeyError) as e:
-            results.append((varname, f"ERROR {model} input variable not found: {e}"))
+            results.append((varname, f"ERROR {model} file not not found: {e}"))
             continue
         except Exception as e:
             logger.warning(

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -624,6 +624,7 @@ def main():
     logger.setLevel(getattr(logging, args.log_level))
     logger.debug(f"Parsed arguments: {args}")
 
+    # Set variables used below
     scratch = os.getenv("SCRATCH")
     OUTDIR = args.outdir
     resolution = args.resolution
@@ -632,28 +633,11 @@ def main():
     realm = args.realm
     logger.debug("Realm is %s", realm)
 
-    mom6_grid = None
+    # Set ocn_grid and ocn_fx_fields
+    # TODO: it looks like ocn_grid is not used after this - so can it
+    # be removed from the input argument list and from cmor_driver.py
     ocn_grid = None
     ocn_fx_fields = None
-
-    # Determine include patterns and frequency
-    include_patterns = get_include_patterns(model, realm, frequency)
-    TSDIR = None
-    # Setup input directory for noresm
-    if args.tsdir:
-        TSDIR = Path(args.tsdir)
-        if not TSDIR.exists():
-            logger.info(f"Time series directory {str(TSDIR)} does not exist")
-            sys.exit(0)
-        timeseries = latest_monthly_file(TSDIR)
-        logger.info(f"latest monthly time series file is {timeseries}")
-    elif model == "noresm":
-        if realm == "atmos":
-            TSDIR = "/nird/datalake/NS9560K/mvertens/test_regridder/atm/timeseries"
-        elif realm == "land":
-            TSDIR = "/nird/datalake/NS9560K/mvertens/test_regridder/lnd/timeseries"
-
-    # Setup input directory for cesm
     if model == "cesm":
         if realm in ["ocean", "seaIce"]:
             if args.ocn_grid_file:
@@ -663,6 +647,23 @@ def main():
                 logger.info(
                     f"Loaded ocean fx fields from {args.ocn_static_file}: {list(ocn_fx_fields.keys())}"
                 )
+
+    # Use tsdir if it is an input argument
+    TSDIR = None
+    if args.tsdir:
+        TSDIR = Path(args.tsdir)
+        if not os.path.exists(TSDIR):
+            logger.error(f"Time series directory {str(TSDIR)} does not exist")
+            sys.exit(1)
+        timeseries = latest_monthly_file(TSDIR)
+        logger.info(f"latest monthly time series file is {timeseries}")
+    else:
+        if model == "noresm":
+            logger.error(f"must specify --tsdir as an input argument for noresm model")
+            sys.exit(1)
+
+    # Setup input directory for cesm
+    if model == "cesm":
         if args.caseroot and args.cimeroot:
             caseroot = args.caseroot
             cimeroot = args.cimeroot
@@ -672,7 +673,7 @@ def main():
             try:
                 from CIME.case import Case
             except ImportError as e:
-                logger.warning(f"Error importing CIME modules: {e}")
+                logger.error(f"Error importing CIME modules: {e}")
                 sys.exit(1)
             with Case(caseroot, read_only=True) as case:
                 inputroot = case.get_value("DOUT_S_ROOT")
@@ -785,6 +786,7 @@ def main():
 
     # Load requested variables
     if len(cmip_vars) > 0:
+        include_patterns = get_include_patterns(model, realm, frequency)
         if len(include_patterns) == 1:
             glob_pattern = f"*{include_patterns[0]}*.nc"
         else:
@@ -814,14 +816,21 @@ def main():
         _default_tables = Path(__file__).parent.parent / "cmip7-cmor-tables"
         if args.tables_root:
             tables_root = Path(args.tables_root)
+            if not Path(tables_root).exists:
+                logger.error(f"input tables-root path {tables_root} does not exist")
+                sys.exit(1)
         elif model == "cesm" and Path(TABLES_cesm).exists():
             tables_root = Path(TABLES_cesm)
         elif model == "noresm" and Path(TABLES_noresm).exists():
             tables_root = Path(TABLES_noresm)
         else:
             tables_root = _default_tables
+            if not Path(tables_root).exists:
+                logger.error(f"default_tables path {tables_root} does not exist")
+                sys.exit(1)
         logger.info(f"Using CMOR tables from: {tables_root}")
 
+        # Determine time series files
         all_ts_files = sorted(Path(TSDIR).glob(glob_pattern))
         logger.info(
             f"Found {len(all_ts_files)} candidate timeseries files matching '{glob_pattern}'"

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -64,7 +64,8 @@ _DATE_RE = re.compile(
 )
 
 # Path for cmor tables
-TABLES_cesm = "/glade/derecho/scratch/jedwards/cmip7-prep/cmip7-cmor-tables/"
+#TABLES_cesm = "/glade/derecho/scratch/jedwards/cmip7-prep/cmip7-cmor-tables/"
+TABLES_cesm = "/nird/datalake/NS9560K/mvertens/packages/cmip7-prep/cmip7-cmor-tables/"
 TABLES_noresm = "/nird/datalake/NS9560K/mvertens/packages/cmip7-prep/cmip7-cmor-tables/"
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -641,9 +642,9 @@ def main():
         logger.info(f"latest monthly time series file is {timeseries}")
     elif model == "noresm":
         if realm == "atmos":
-            TSDIR = "/datalake/NS9560K/mvertens/test_regridder/atm/timeseries"
+            TSDIR = "/nird/datalake/NS9560K/mvertens/test_regridder/atm/timeseries"
         elif realm == "land":
-            TSDIR = "/datalake/NS9560K/mvertens/test_regridder/lnd/timeseries"
+            TSDIR = "/nird/datalake/NS9560K/mvertens/test_regridder/lnd/timeseries"
 
     # Setup input directory for cesm
     if model == "cesm":

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -490,8 +490,8 @@ def process_one_var(
                     ds_cmor = ds_cmor.merge(ocn_fx_fields)
                 cmor_items = [(ds_cmor, cfg)]
 
-        except AttributeError:
-            results.append((varname, f"ERROR {model} input variable not found."))
+        except (FileNotFoundError, KeyError) as e:
+            results.append((varname, f"ERROR {model} input variable not found: {e}"))
             continue
         except Exception as e:
             logger.warning(

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -259,6 +259,12 @@ def parse_args():
         default=False,
         help="Path to custom YAML mapping file (optional, overrides default packaged YAML)",
     )
+    parser.add_argument(
+        "--tables-root",
+        type=str,
+        default=None,
+        help="Path to cmip7-cmor-tables directory (optional, overrides model-specific default)",
+    )
 
     args = parser.parse_args()
     return args
@@ -803,10 +809,16 @@ def main():
         mapping.default_freq = frequency
 
         # Determine TABLES directory
-        if model == "cesm":
+        _default_tables = Path(__file__).parent.parent / "cmip7-cmor-tables"
+        if args.tables_root:
+            tables_root = Path(args.tables_root)
+        elif model == "cesm" and Path(TABLES_cesm).exists():
             tables_root = Path(TABLES_cesm)
-        else:
+        elif model == "noresm" and Path(TABLES_noresm).exists():
             tables_root = Path(TABLES_noresm)
+        else:
+            tables_root = _default_tables
+        logger.info(f"Using CMOR tables from: {tables_root}")
 
         all_ts_files = sorted(Path(TSDIR).glob(glob_pattern))
         logger.info(

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -625,7 +625,6 @@ def main():
     logger.debug(f"Parsed arguments: {args}")
 
     # Set variables used below
-    scratch = os.getenv("SCRATCH")
     OUTDIR = args.outdir
     resolution = args.resolution
     model = args.model
@@ -648,7 +647,7 @@ def main():
                     f"Loaded ocean fx fields from {args.ocn_static_file}: {list(ocn_fx_fields.keys())}"
                 )
 
-    # Use tsdir if it is an input argument
+    # Determine TSDIR
     TSDIR = None
     if args.tsdir:
         TSDIR = Path(args.tsdir)
@@ -661,64 +660,35 @@ def main():
         if model == "noresm":
             logger.error(f"must specify --tsdir as an input argument for noresm model")
             sys.exit(1)
-
-    # Setup input directory for cesm
-    if model == "cesm":
-        if args.caseroot and args.cimeroot:
-            caseroot = args.caseroot
-            cimeroot = args.cimeroot
-            sys.path.append(cimeroot)
-            _LIBDIR = os.path.join(cimeroot, "CIME", "Tools")
-            sys.path.append(_LIBDIR)
-            try:
-                from CIME.case import Case
-            except ImportError as e:
-                logger.error(f"Error importing CIME modules: {e}")
+        elif model == "cesm":
+            if args.caseroot and args.cimeroot:
+                caseroot = args.caseroot
+                cimeroot = args.cimeroot
+                sys.path.append(cimeroot)
+                _LIBDIR = os.path.join(cimeroot, "CIME", "Tools")
+                sys.path.append(_LIBDIR)
+                try:
+                    from CIME.case import Case
+                except ImportError as e:
+                    logger.error(f"Error importing CIME modules: {e}")
+                    sys.exit(1)
+                with Case(caseroot, read_only=True) as case:
+                    inputroot = case.get_value("DOUT_S_ROOT")
+                    casename = case.get_value("CASE")
+                if realm in ("atmos", "aerosol", "atmosChem"):
+                    TSDIR = Path(inputroot) / "atm" / "proc" / "tseries"
+                elif realm == "land":
+                    TSDIR = Path(inputroot) / "lnd" / "proc" / "tseries"
+                elif realm in ("ocean", "ocnBgchem"):
+                    TSDIR = Path(inputroot) / "ocn" / "proc" / "tseries"
+                elif realm == "seaIce":
+                    TSDIR = Path(inputroot) / "ice" / "proc" / "tseries"
+                elif realm == "landIce":
+                    TSDIR = Path(inputroot) / "glc" / "proc" / "tseries"
+                TSDIR = TSDIR / args.frequency
+            else:
+                logger.error(f"no TSDIR found for cesm model model")
                 sys.exit(1)
-            with Case(caseroot, read_only=True) as case:
-                inputroot = case.get_value("DOUT_S_ROOT")
-                casename = case.get_value("CASE")
-            if realm in ("atmos", "aerosol", "atmosChem"):
-                TSDIR = Path(inputroot) / "atm" / "proc" / "tseries"
-            elif realm == "land":
-                TSDIR = Path(inputroot) / "lnd" / "proc" / "tseries"
-            elif realm in ("ocean", "ocnBgchem"):
-                TSDIR = Path(inputroot) / "ocn" / "proc" / "tseries"
-            elif realm == "seaIce":
-                TSDIR = Path(inputroot) / "ice" / "proc" / "tseries"
-            elif realm == "landIce":
-                TSDIR = Path(inputroot) / "glc" / "proc" / "tseries"
-            TSDIR = TSDIR / args.frequency
-        elif not TSDIR or not os.path.exists(TSDIR):
-            # testing path
-            scratch = os.getenv("SCRATCH")
-            if realm == "atmos":
-                TSDIR = (
-                    Path(scratch)
-                    / "archive"
-                    / "timeseries"
-                    / "b.e30_beta06.B1850C_LTso.ne30_t232_wgx3.192.wrkflw.1"
-                    / "atm"
-                    / "hist"
-                )
-            elif realm == "land":
-                TSDIR = (
-                    Path(scratch)
-                    / "archive"
-                    / "timeseries"
-                    / "b.e30_beta06.B1850C_LTso.ne30_t232_wgx3.192.wrkflw.1"
-                    / "lnd"
-                    / "hist"
-                )
-            elif realm == "ocean":
-                TSDIR = (
-                    Path(scratch)
-                    / "archive"
-                    / "timeseries"
-                    / "b.e30_beta06.B1850C_LTso.ne30_t232_wgx3.192.wrkflw.1"
-                    / "ocn"
-                    / "hist"
-                )
 
     # Make output directory if it does not exist
     OUTDIR = Path(args.outdir)

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -187,6 +187,7 @@ def parse_args():
             "ne16",
             "ne30",
             "tx2_3v2",
+            "tnx1v4",
             "regular",
         ],
         default="ne30",

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -496,14 +496,13 @@ def process_one_var(
             results.append((varname, f"ERROR {model} file not not found: {e}"))
             continue
         except Exception as e:
-            logger.warning(
+            logger.error(
                 "Exception during regridding of %s with dims %s: %r",
                 varname,
                 dims,
                 e,
             )
-            results.append((varname, f"ERROR during regridding: {e!r}"))
-            continue
+            raise
 
         # ---------------------------------------------
         # CMORize — loop over variants (usually just one)

--- a/scripts/gen_timeseries.py
+++ b/scripts/gen_timeseries.py
@@ -52,7 +52,7 @@ def parse_arguments():
     )
     parser.add_argument(
         "--realm",
-        choices=["atmos", "land"],
+        choices=["atmos", "land", "seaIce"],
         help="Realm to process - sets include patterns for time series (required)",
         required=True,
     )
@@ -118,6 +118,8 @@ def main():
         include_patterns = ["*cam.h0a*", "*cam.h1a*", "*cam.h2a*", "*cam.h3a*"]
     elif args.realm == "land":
         include_patterns = ["*clm2.h0a*", "*clm2.h0i*"]
+    elif args.realm == "seaIce":
+        include_patterns = ["*.cice.h1.*"]
 
     # Determine input directory
     inputdir = Path(args.inputdir)

--- a/scripts/gen_timeseries.py
+++ b/scripts/gen_timeseries.py
@@ -119,7 +119,7 @@ def main():
     elif args.realm == "land":
         include_patterns = ["*clm2.h0a*", "*clm2.h0i*"]
     elif args.realm == "seaIce":
-        include_patterns = ["*.cice.h1.*"]
+        include_patterns = ["*cice.h.*", "*.cice.h1.*"]
 
     # Determine input directory
     inputdir = Path(args.inputdir)

--- a/src/cmip7_prep/regrid.py
+++ b/src/cmip7_prep/regrid.py
@@ -30,7 +30,7 @@ except ModuleNotFoundError as e:
 # Default weight maps; override via function args.
 # optional bilinear map
 
-INPUTDATA_DIR_noresm = Path("/datalake/NS9560K/diagnostics/land_xesmf_diag_data/")
+INPUTDATA_DIR_noresm = Path("/nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/")
 DEFAULT_BILIN_MAP_NE30_noresm = Path(
     INPUTDATA_DIR_noresm / "map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc"
 )

--- a/src/cmip7_prep/regrid.py
+++ b/src/cmip7_prep/regrid.py
@@ -27,22 +27,33 @@ try:
 except ModuleNotFoundError as e:
     _HAS_DASK = False
 
-# Default weight maps; override via function args.
-# optional bilinear map
+#---------------------------------------------------------
+# Default NorESM weight maps; override via function args.
+#---------------------------------------------------------
 
 INPUTDATA_DIR_noresm = Path("/nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/")
-DEFAULT_BILIN_MAP_NE30_noresm = Path(
-    INPUTDATA_DIR_noresm / "map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc"
-)
 DEFAULT_CONS_MAP_NE30_noresm = Path(
-    INPUTDATA_DIR_noresm / "map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc"
+    INPUTDATA_DIR_noresm / "map_ne30pg3_to_1x1_aave.nc"
 )
-DEFAULT_BILIN_MAP_NE16_noresm = Path(
-    INPUTDATA_DIR_noresm / "map_ne16pg3_to_1.9x2.5_nomask_scripgrids_c250425.nc"
+DEFAULT_BILIN_MAP_NE30_noresm = Path(
+    INPUTDATA_DIR_noresm / "map_ne30pg3_to_1x1_bilin.nc"
 )
 DEFAULT_CONS_MAP_NE16_noresm = Path(
-    INPUTDATA_DIR_noresm / "map_ne16pg3_to_1.9x2.5_nomask_scripgrids_c250425.nc"
+    INPUTDATA_DIR_noresm / "map_ne16pg3_to_2x2_aave_c260531.nc"
 )
+DEFAULT_BILIN_MAP_NE16_noresm = Path(
+    INPUTDATA_DIR_noresm / "map_ne16pg3_to_2x2_blin_c260531.nc"
+)
+DEFAULT_CONS_MAP_TNX1V4 = Path(
+    INPUTDATA_DIR_cesm / "map_tnx1v4_to_1x1_aave_c260531.nc"
+)
+DEFAULT_BILIN_MAP_TNX1V4 = Path(
+    INPUTDATA_DIR_cesm / "map_tnx1v4_to_1x1_blin_c260531.nc"
+)
+
+#---------------------------------------------------------
+# Default CESM weight maps; override via function args.
+#---------------------------------------------------------
 
 INPUTDATA_DIR_cesm = Path("/glade/campaign/cesm/cesmdata/inputdata/")
 DEFAULT_CONS_MAP_NE30_cesm = Path(
@@ -57,6 +68,10 @@ DEFAULT_CONS_MAP_T232 = Path(
 DEFAULT_BILIN_MAP_T232 = Path(
     INPUTDATA_DIR_cesm / "cpl/gridmaps/tx2_3v2/map_t232_TO_1x1d_blin.251023.nc"
 )  # optional bilinear map
+
+#---------------------------------------------------------
+# Intensive variables
+#---------------------------------------------------------
 
 INTENSIVE_VARS = {
     "tas",
@@ -277,6 +292,9 @@ def _pick_maps(
             bilin = (
                 Path(bilinear_map) if bilinear_map else DEFAULT_BILIN_MAP_NE16_noresm
             )
+        else:
+            cons = Path(conservative_map) if conservative_map else DEFAULT_CONS_MAP_TNX1V4
+            bilin = Path(bilinear_map) if bilinear_map else DEFAULT_BILIN_MAP_TNX1V4
 
     if force_method:
         if force_method not in {"conservative", "bilinear"}:

--- a/src/cmip7_prep/regrid.py
+++ b/src/cmip7_prep/regrid.py
@@ -45,10 +45,10 @@ DEFAULT_BILIN_MAP_NE16_noresm = Path(
     INPUTDATA_DIR_noresm / "map_ne16pg3_to_2x2_blin_c260531.nc"
 )
 DEFAULT_CONS_MAP_TNX1V4 = Path(
-    INPUTDATA_DIR_cesm / "map_tnx1v4_to_1x1_aave_c260531.nc"
+    INPUTDATA_DIR_noresm / "map_tnx1v4_to_1x1_aave_c260531.nc"
 )
 DEFAULT_BILIN_MAP_TNX1V4 = Path(
-    INPUTDATA_DIR_cesm / "map_tnx1v4_to_1x1_blin_c260531.nc"
+    INPUTDATA_DIR_noresm / "map_tnx1v4_to_1x1_blin_c260531.nc"
 )
 
 #---------------------------------------------------------

--- a/src/cmip7_prep/regrid.py
+++ b/src/cmip7_prep/regrid.py
@@ -451,9 +451,13 @@ def regrid_to_latlon(
 
     # TODO: handle if the lat, lon coords are already present, but still on the wrong grid
     # or other changes to the grid should be made.
-    if "lat" in var_da.dims and "lon" in var_da.dims:
-        logger.info("Variable already has 'lat' and 'lon' dims; skipping regridding.")
-        return var_da
+    if resolution == 'regular':
+        if "lat" in var_da.dims and "lon" in var_da.dims:
+            logger.info("Variable already has 'lat' and 'lon' dims; skipping regridding.")
+            return var_da
+        else:
+            raise KeyError(f"regular grid is requested but variable does not have 'lat','lon' dims")
+
     if "ncol" not in var_da.dims and "lndgrid" not in var_da.dims:
         logger.info(
             "Variable has no 'ncol' or 'lndgrid' dim; assuming ocean or seaIce variable."

--- a/src/cmip7_prep/regrid.py
+++ b/src/cmip7_prep/regrid.py
@@ -278,6 +278,12 @@ def _pick_maps(
                 Path(bilinear_map) if bilinear_map else DEFAULT_BILIN_MAP_NE16_noresm
             )
 
+    if cons is None and bilin is None:
+        raise FileNotFoundError(
+            f"No regrid weight file defined for model={model!r}, resolution={resolution!r}. "
+            "Add an entry to _pick_maps in regrid.py or pass --conservative-map / --bilinear-map."
+        )
+
     if force_method:
         if force_method not in {"conservative", "bilinear"}:
             raise ValueError("force_method must be 'conservative' or 'bilinear'")
@@ -285,6 +291,10 @@ def _pick_maps(
             if not bilin or not str(bilin):
                 raise FileNotFoundError("Bilinear map requested but not provided.")
             return MapSpec("bilinear", bilin)
+        if cons is None:
+            raise FileNotFoundError(
+                f"Conservative map not defined for model={model!r}, resolution={resolution!r}."
+            )
         return MapSpec("conservative", cons)
 
     if varname in INTENSIVE_VARS and bilin and str(bilin):


### PR DESCRIPTION
  Summary:

  - seaIce realm added — cmor_driver.py now handles sea ice processing; noresm_to_cmip7_seaice.yaml is populated with sea ice variable mappings.
  - NorESM tnx1v4 regrid support — Added conservative and bilinear weight map entries for the NorESM tripolar ocean grid (tnx1v4 → 1°) in regrid.py. Also added a --resolution tnx1v4 option to the argument parser.
  - --tables-root argument — Tables path is now a command-line argument rather than a hardcoded constant.
  - regular resolution added — New resolution option for pre-regridded regular lat/lon input.
  - Error handling hardened — Missing regrid weight files now raise a clear FileNotFoundError instead of propagating as a misleading AttributeError masked as "input variable not found". Regridding exceptions are now logged at
  ERROR level and re-raised rather than silently continuing.
  - plev39 vertical interpolation fixes — Corrects a shape mismatch where the zonal mean was taken before pressure interpolation; PS is now correctly used at every lat/lon point before averaging.

