### PR TITLE
Wiemip variable addition exploration

### DIFF
--- a/data/cmor_dataset_noresm.json
+++ b/data/cmor_dataset_noresm.json
@@ -32,7 +32,7 @@
   "sub_experiment": "none",
     "archive_id": "WCRP",
     "area_label" : "u",
-    "license_id": "CC-BY-4-0",
+    "license_id": "CC-BY-4.0",
   "realization_index": "r1",
   "initialization_index": "i1",
   "physics_index": "p1",

--- a/data/noresm_to_cmip7_land.yaml
+++ b/data/noresm_to_cmip7_land.yaml
@@ -217,6 +217,7 @@ variables:
   evspsblsoi_tavg-u-hxy-u:
     description: Water evaporation from soil
     dims: [lon, lat, time]
+    positive: up
     sources: [model_var: QSOIL]
     table: land
     units: kg m-2 s-1
@@ -231,6 +232,7 @@ variables:
   evspsblveg_tavg-u-hxy-u:
     description: Evaporation from canopy
     dims: [lon, lat, time]
+    positive: up
     sources: [model_var: QVEGE]
     table: land
     units: kg m-2 s-1
@@ -551,7 +553,7 @@ variables:
   grassFracC3_tavg-u-hxy-u:
     description: Percentage of entire grid cell covered by C3 natural grass.
     dims: [lon, lat, time, typec3natg]
-    formula: (FATES_CROWNAREA_PF(12+13))*FATES_FRACTION
+    formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[12, 13], dimname='fates_levpft'))*FATES_FRACTION
     sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -41,6 +41,7 @@ from cmip7_prep.pipeline import (
 )
 from cmip7_prep.cmor_writer import CmorSession
 from cmip7_prep.mom6_static import ocean_fx_fields
+from cmip7_prep.variable_selection import assemble_yaml_defined_cmip_vars
 
 from data_request_api.query import data_request as dr
 from data_request_api.content import dump_transformation as dt
@@ -267,6 +268,11 @@ def parse_args():
         default=None,
         help="Path to cmip7-cmor-tables directory (optional, overrides model-specific default)",
     )
+    parser.add_argument(
+        "--run-all-from-yaml",
+        default=False,
+        help="Override CMIP7 data request variable list and run all variables defined in the YAML mapping file",
+    )
 
     args = parser.parse_args()
     return args
@@ -277,6 +283,13 @@ def get_version():
     from cmip7_prep import __version__
 
     return __version__
+
+
+def _priority_for_logging(data_request, cmip_var) -> str:
+    """Return a stable priority label for logs, including synthetic variables."""
+    if getattr(cmip_var, "is_synthetic", False):
+        return "synthetic-from-yaml"
+    return str(data_request.find_priority_per_variable(variable=cmip_var))
 
 
 def process_one_var(
@@ -694,6 +707,27 @@ def main():
     if not os.path.exists(str(OUTDIR)):
         os.makedirs(str(OUTDIR))
 
+
+    # Load and evaluate the CMIP mapping YAML file for this model and realm
+    if custom_yaml := args.custom_yaml:
+        logger.info(f"Using custom YAML mapping file: {custom_yaml}")
+        mapping = Mapping.from_yaml(custom_yaml)
+    else:
+        if model not in REALM_YAML_MAP:
+            logger.error(
+                f"Unknown model '{model}': must be one of {list(REALM_YAML_MAP)}"
+            )
+            sys.exit(1)
+        yaml_filename = REALM_YAML_MAP[model].get(realm)
+        if yaml_filename is None:
+            logger.error(
+                f"No YAML mapping defined for model={model}, realm={realm}"
+            )
+            sys.exit(1)
+        logger.info(f"Loading mapping YAML: {yaml_filename}")
+        mapping = Mapping.from_packaged_default(filename=yaml_filename)
+    mapping.default_freq = frequency
+
     # Load all possible cmip vars for this realm and this experiment
     # The data_request_api is a CMIP7-specific Python package that is
     # separate from CMOR itself but closely related to it.
@@ -703,7 +737,6 @@ def main():
     logger.info("Content dictionary obtained")
     DR = dr.DataRequest.from_separated_inputs(**content_dic)
     cmip_vars = []
-    print(DR.get_experiments())
     cmip_vars = DR.find_variables(
         skip_if_missing=False,
         operation="all",
@@ -711,6 +744,29 @@ def main():
         modelling_realm=realm,
         experiment=args.experiment,
     )
+    cmip_vars_rich = DR.find_variables(
+        skip_if_missing=False,
+        operation="all",
+        cmip7_frequency=frequency,
+        modelling_realm=realm,
+    )
+    if args.run_all_from_yaml:
+        logger.info(
+            "Running with --run-all-from-yaml: assembling variables from the YAML mapping"
+        )
+        cmip_vars, synthesized_names = assemble_yaml_defined_cmip_vars(
+            mapping,
+            cmip_vars_rich,
+            freq=frequency,
+        )
+        logger.info(
+            "Resolved %s YAML variables: %s reused from data request, %s synthesized",
+            len(cmip_vars),
+            len(cmip_vars) - len(synthesized_names),
+            len(synthesized_names),
+        )
+        for varname in synthesized_names:
+            logger.info("Synthesized variable %s from YAML mapping", varname)
     # cmip_vars = [var for var in cmip_vars if getattr(var, "region", "") == "glb"]
 
     # Determine cmip variables that will process
@@ -729,7 +785,7 @@ def main():
                 logger.info(
                     "Adding variable %s with priority %s",
                     var.branded_variable_name.name,
-                    DR.find_priority_per_variable(variable=var),
+                    _priority_for_logging(DR, var),
                 )
                 if var.branded_variable_name.name not in [
                     v.branded_variable_name.name for v in cmip_vars
@@ -762,25 +818,6 @@ def main():
         else:
             glob_pattern = "*.nc"
 
-        # Load and evaluate the CMIP mapping YAML file for this model and realm
-        if custom_yaml := args.custom_yaml:
-            logger.info(f"Using custom YAML mapping file: {custom_yaml}")
-            mapping = Mapping.from_yaml(custom_yaml)
-        else:
-            if model not in REALM_YAML_MAP:
-                logger.error(
-                    f"Unknown model '{model}': must be one of {list(REALM_YAML_MAP)}"
-                )
-                sys.exit(1)
-            yaml_filename = REALM_YAML_MAP[model].get(realm)
-            if yaml_filename is None:
-                logger.error(
-                    f"No YAML mapping defined for model={model}, realm={realm}"
-                )
-                sys.exit(1)
-            logger.info(f"Loading mapping YAML: {yaml_filename}")
-            mapping = Mapping.from_packaged_default(filename=yaml_filename)
-        mapping.default_freq = frequency
 
         # Determine TABLES directory
         _default_tables = Path(__file__).parent.parent / "cmip7-cmor-tables"
@@ -879,6 +916,19 @@ def main():
         client.close()
     if cluster:
         cluster.close()
+
+def make_cmip_vars_from_full_yaml(mapping: Mapping) -> list[dr.Variable]:
+    """Utility function to create a list of dr.Variable objects for all variables defined in the YAML mapping."""
+    cmip_vars = []
+    for varname in mapping.mapping.keys():
+        print(varname)
+        sys.exit(4)
+        # cmip_var = dr.Variable(
+        #     branded_variable_name=varname,
+        #     dr="fix",
+        # )
+
+
 
 
 if __name__ == "__main__":

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -919,20 +919,6 @@ def main():
     if cluster:
         cluster.close()
 
-def make_cmip_vars_from_full_yaml(mapping: Mapping) -> list[dr.Variable]:
-    """Utility function to create a list of dr.Variable objects for all variables defined in the YAML mapping."""
-    cmip_vars = []
-    for varname in mapping.mapping.keys():
-        print(varname)
-        sys.exit(4)
-        # cmip_var = dr.Variable(
-        #     branded_variable_name=varname,
-        #     dr="fix",
-        # )
-
-
-
-
 if __name__ == "__main__":
     args = parse_args()
     if getattr(args, "version", False):

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -224,8 +224,8 @@ def parse_args():
         "--frequency",
         type=str,
         default="mon",
-        choices=["mon", "day", "6hr", "3hr"],
-        help="Frequency of data to be translated (mon, day, 6hr, 3hr), (Default: mon)",
+        choices=["mon", "day", "6hr", "3hr", "yr"],
+        help="Frequency of data to be translated (mon, day, 6hr, 3hr, yr), (Default: mon)",
     )
     parser.add_argument(
         "--outdir",

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -270,7 +270,7 @@ def parse_args():
     )
     parser.add_argument(
         "--run-all-from-yaml",
-        default=False,
+        action="store_true",
         help="Override CMIP7 data request variable list and run all variables defined in the YAML mapping file",
     )
 

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -236,8 +236,8 @@ def parse_args():
     parser.add_argument(
         "--experiment",
         type=str,
-        default="piControl",
-        help="Experiment name for data request. (Default piControl)",
+        default="picontrol",
+        help="Experiment name for data request. (Default picontrol)",
     )
     parser.add_argument(
         "--model",
@@ -703,6 +703,7 @@ def main():
     logger.info("Content dictionary obtained")
     DR = dr.DataRequest.from_separated_inputs(**content_dic)
     cmip_vars = []
+    print(DR.get_experiments())
     cmip_vars = DR.find_variables(
         skip_if_missing=False,
         operation="all",

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -757,7 +757,9 @@ def main():
         cmip_vars, synthesized_names = assemble_yaml_defined_cmip_vars(
             mapping,
             cmip_vars_rich,
+            data_request=DR,
             freq=frequency,
+            realm=realm,
         )
         logger.info(
             "Resolved %s YAML variables: %s reused from data request, %s synthesized",

--- a/scripts/validate_cmor_output.py
+++ b/scripts/validate_cmor_output.py
@@ -434,7 +434,7 @@ def scan_output_tree(
         if not path_matches_resolution(
             resolution, dimension_folder, grid_type, file_path.name
         ):
-            print("Skipping due to resolution filter: %s", resolution)
+            logger.debug("Skipping due to resolution filter: %s", resolution)
             continue
 
         produced[variable].append(file_path)

--- a/scripts/validate_cmor_output.py
+++ b/scripts/validate_cmor_output.py
@@ -23,7 +23,6 @@ import json
 import logging
 import re
 import sys
-import glob
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -395,26 +394,12 @@ def scan_output_tree(
     produced: dict[str, list[Path]] = defaultdict(list)
     inventory: list[ProducedFileRecord] = []
     inspection_errors: list[dict[str, str]] = []
-    print(cmip_root)
     institution_id = MODEL_NAMING_MAPS[model][0]
-    print(
-        f"{cmip_root}/CMIP/{institution_id}/{MODEL_NAMING_MAPS[model][1]}/{experiment}/*/glb/{frequency}/*/*/*/*.nc"
-    )
-    print(
-        glob.glob(
-            f"{cmip_root}/CMIP/{institution_id}/{MODEL_NAMING_MAPS[model][1]}/{experiment}/*/glb/{frequency}/*/*/*/*.nc"
-        )
-    )
     pattern = cmip_root.glob(
         f"CMIP/{institution_id}/{MODEL_NAMING_MAPS[model][1]}/{experiment}/*/glb/{frequency}/*/*/*/*.nc"
     )
-    # print(list(pattern))
-    # sys.exit(4)
-    print(expected_variables)
-    # sys.exit(4)
     for file_path in sorted(pattern):
         relative = file_path.relative_to(cmip_root)
-        print(relative)
         # sys.exit(4)
         parts = relative.parts
         if len(parts) < 11:

--- a/scripts/validate_cmor_output.py
+++ b/scripts/validate_cmor_output.py
@@ -1,0 +1,786 @@
+#!/usr/bin/env python3
+
+"""Quick-check validation for CMORized CMIP7 output trees.
+
+This script validates a selected CMIP7 output subset after ``cmor_driver.py``
+has run. It reports:
+
+* variables with CMOR log errors
+* variables expected for the selected subset that were not produced
+* dimension inventory for variables that were produced
+
+It can also optionally create:
+
+* composite mean time-series plots for produced variables
+* per-variable time-mean maps where the data are on plottable lat/lon grids
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import re
+import sys
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import xarray as xr
+import yaml
+
+from cmip7_prep.mapping_compat import packaged_mapping_resource
+
+
+logger = logging.getLogger("cmip7_prep.validate_cmor_output")
+
+
+REALM_YAML_MAP = {
+    "noresm": {
+        "atmos": "noresm_to_cmip7_atmos.yaml",
+        "land": "noresm_to_cmip7_land.yaml",
+        "seaIce": "noresm_to_cmip7_seaice.yaml",
+    },
+    "cesm": {
+        "atmos": "cesm_to_cmip7_atmos.yaml",
+        "land": "cesm_to_cmip7_land.yaml",
+        "landIce": "cesm_to_cmip7_landice.yaml",
+        "seaIce": "cesm_to_cmip7_seaice.yaml",
+        "ocean": "cesm_to_cmip7_ocean.yaml",
+    },
+}
+
+CANONICAL_REALM_MAP = {
+    "aerosol": "atmos",
+    "atmosChem": "atmos",
+    "ocnBgchem": "ocean",
+}
+
+LOG_NAME_RE = re.compile(r"^cmor_\d{8}T\d{6}Z_(?P<variable>.+)\.log$")
+LOG_ERROR_RE = re.compile(r"\b(error|exception|traceback|fatal)\b", re.IGNORECASE)
+LOG_SUCCESS_RE = re.compile(r"\b(success|complete(?:d)?|finished)\b", re.IGNORECASE)
+
+
+@dataclass
+class LogRecord:
+    """A parsed record for one CMOR log file."""
+
+    variable: str
+    path: str
+    has_error: bool
+    has_success_marker: bool
+    error_lines: list[str]
+
+
+@dataclass
+class ProducedFileRecord:
+    """Inventory record for one produced CMOR file."""
+
+    variable: str
+    consortium: str
+    model: str
+    experiment: str
+    ensemble_member: str
+    region: str
+    frequency: str
+    dimension_folder: str
+    grid_type: str
+    file_path: str
+    data_var: str
+    dims: list[str]
+    sizes: dict[str, int]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Quick-check validation for CMIP7 CMOR output trees"
+    )
+    parser.add_argument(
+        "--model",
+        choices=sorted(REALM_YAML_MAP),
+        required=True,
+        help="Model whose CMIP7 output should be validated",
+    )
+    parser.add_argument(
+        "--realm",
+        choices=[
+            "atmos",
+            "aerosol",
+            "atmosChem",
+            "land",
+            "landIce",
+            "ocean",
+            "ocnBgchem",
+            "seaIce",
+        ],
+        required=True,
+        help="Realm to validate; aerosol/atmosChem map to atmos YAML, ocnBgchem maps to ocean YAML",
+    )
+    parser.add_argument(
+        "--experiment",
+        required=True,
+        help="Experiment name to validate",
+    )
+    parser.add_argument(
+        "--frequency",
+        choices=["mon", "day", "6hr", "3hr", "yr", "fx"],
+        required=True,
+        help="CMIP7 output frequency to validate",
+    )
+    parser.add_argument(
+        "--resolution",
+        default=None,
+        help="Optional best-effort filter applied to dimension folder, grid type and file name",
+    )
+    parser.add_argument(
+        "--root-output-path",
+        required=True,
+        help="Root output directory containing CMIP7/ and logs/",
+    )
+    parser.add_argument(
+        "--ensemble-member",
+        default=None,
+        help="Optional ensemble member filter",
+    )
+    parser.add_argument(
+        "--institution-id",
+        default=None,
+        help="Optional consortium/institution segment filter in the CMIP7 path",
+    )
+    parser.add_argument(
+        "--custom-yaml",
+        default=None,
+        help="Optional custom YAML mapping file",
+    )
+    parser.add_argument(
+        "--variables",
+        nargs="*",
+        default=None,
+        help="Optional explicit list of branded variable names to validate",
+    )
+    parser.add_argument(
+        "--report-dir",
+        default=None,
+        help="Directory for validation reports; defaults to <root-output-path>/validation_reports/<subset>",
+    )
+    parser.add_argument(
+        "--plot-timeseries",
+        action="store_true",
+        help="Create composite mean time-series plots for produced variables",
+    )
+    parser.add_argument(
+        "--plot-maps",
+        action="store_true",
+        help="Create per-variable time-mean maps where possible",
+    )
+    parser.add_argument(
+        "--plot-dir",
+        default=None,
+        help="Output directory for plot files; defaults to <report-dir>/plots",
+    )
+    parser.add_argument(
+        "--max-plots",
+        type=int,
+        default=36,
+        help="Maximum number of variables to plot per plot mode",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with code 1 if missing variables or log errors are found",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level",
+    )
+    return parser.parse_args()
+
+
+def canonical_realm(realm: str) -> str:
+    """Return the YAML realm corresponding to the requested realm."""
+    return CANONICAL_REALM_MAP.get(realm, realm)
+
+
+def resolve_cmip_root(root_output_path: str | Path) -> Path:
+    """Resolve the CMIP7 root directory from either a parent or direct path."""
+    root = Path(root_output_path).expanduser().resolve()
+    if root.name == "CMIP7" and (root / "CMIP").is_dir():
+        return root
+    cmip_root = root / "CMIP7"
+    if cmip_root.is_dir() and (cmip_root / "CMIP").is_dir():
+        return cmip_root
+    raise FileNotFoundError(
+        f"Could not locate CMIP7/CMIP under {root}. Expected either {root / 'CMIP7'} or a direct CMIP7 path."
+    )
+
+
+def resolve_logs_dir(root_output_path: str | Path, cmip_root: Path) -> Path:
+    """Resolve the logs directory adjacent to the CMIP7 output tree."""
+    root = Path(root_output_path).expanduser().resolve()
+    if (root / "logs").is_dir():
+        return root / "logs"
+    if (cmip_root.parent / "logs").is_dir():
+        return cmip_root.parent / "logs"
+    return root / "logs"
+
+
+def default_report_dir(args: argparse.Namespace) -> Path:
+    """Compute the default report directory for a validation subset."""
+    root = Path(args.root_output_path).expanduser().resolve()
+    subset = f"{args.model}_{args.realm}_{args.experiment}_{args.frequency}"
+    return root / "validation_reports" / subset
+
+
+def get_yaml_path(model: str, realm: str, custom_yaml: str | None) -> Path:
+    """Resolve the YAML mapping path for the selected model/realm."""
+    if custom_yaml:
+        path = Path(custom_yaml).expanduser().resolve()
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        return path
+
+    yaml_realm = canonical_realm(realm)
+    yaml_name = REALM_YAML_MAP.get(model, {}).get(yaml_realm)
+    if yaml_name is None:
+        raise ValueError(f"No YAML mapping defined for model={model}, realm={realm}")
+    with packaged_mapping_resource(yaml_name) as resource_path:
+        return Path(resource_path)
+
+
+def load_yaml_variables(yaml_path: Path) -> dict[str, dict[str, Any]]:
+    """Load the variables block from a CMIP7 mapping YAML file."""
+    with open(yaml_path, encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+    variables = payload.get("variables")
+    if not isinstance(variables, dict):
+        raise ValueError(f"Unsupported YAML structure in {yaml_path}: expected top-level variables dict")
+    return variables
+
+
+def get_requested_variables(
+    realm: str,
+    experiment: str,
+    frequency: str,
+) -> set[str] | None:
+    """Query the CMIP7 data request, if the package is available."""
+    try:
+        from data_request_api.content import dump_transformation as dt
+        from data_request_api.query import data_request as dr
+    except ImportError:
+        logger.warning(
+            "data_request_api is not available; expected-variable filtering will use YAML only"
+        )
+        return None
+
+    logger.info(
+        "Querying data request for realm=%s experiment=%s frequency=%s",
+        realm,
+        experiment,
+        frequency,
+    )
+    content_dic = dt.get_transformed_content()
+    data_request = dr.DataRequest.from_separated_inputs(**content_dic)
+    cmip_vars = data_request.find_variables(
+        skip_if_missing=False,
+        operation="all",
+        cmip7_frequency=frequency,
+        modelling_realm=realm,
+        experiment=experiment,
+    )
+    return {var.branded_variable_name.name for var in cmip_vars}
+
+
+def filter_expected_variables(
+    yaml_variables: dict[str, dict[str, Any]],
+    requested_variables: set[str] | None,
+    selected_variables: list[str] | None,
+) -> list[str]:
+    """Resolve the expected variable list for this validation subset."""
+    yaml_names = set(yaml_variables)
+    if requested_variables is not None:
+        yaml_names &= requested_variables
+    if selected_variables:
+        yaml_names &= set(selected_variables)
+    return sorted(yaml_names)
+
+
+def parse_log_variable(log_path: Path) -> str | None:
+    """Extract the CMIP variable name from a CMOR log filename."""
+    match = LOG_NAME_RE.match(log_path.name)
+    if match is None:
+        return None
+    return match.group("variable")
+
+
+def parse_log_file(log_path: Path) -> LogRecord | None:
+    """Parse one CMOR log file for basic error markers."""
+    variable = parse_log_variable(log_path)
+    if variable is None:
+        return None
+    text = log_path.read_text(encoding="utf-8", errors="ignore")
+    error_lines = []
+    for line in text.splitlines():
+        if LOG_ERROR_RE.search(line):
+            error_lines.append(line.strip())
+    return LogRecord(
+        variable=variable,
+        path=str(log_path),
+        has_error=bool(error_lines),
+        has_success_marker=bool(LOG_SUCCESS_RE.search(text)),
+        error_lines=error_lines[:10],
+    )
+
+
+def collect_log_records(log_dir: Path, expected_variables: set[str]) -> dict[str, list[LogRecord]]:
+    """Collect log records for variables that belong to the selected subset."""
+    records: dict[str, list[LogRecord]] = defaultdict(list)
+    if not log_dir.is_dir():
+        logger.warning("Log directory not found: %s", log_dir)
+        return records
+    for log_path in sorted(log_dir.glob("*.log")):
+        record = parse_log_file(log_path)
+        if record is None:
+            continue
+        if expected_variables and record.variable not in expected_variables:
+            continue
+        records[record.variable].append(record)
+    return records
+
+
+def path_matches_resolution(
+    resolution: str | None,
+    dimension_folder: str,
+    grid_type: str,
+    file_name: str,
+) -> bool:
+    """Apply a best-effort resolution filter to discovered output paths."""
+    if not resolution:
+        return True
+    target = resolution.lower()
+    candidates = (dimension_folder.lower(), grid_type.lower(), file_name.lower())
+    return any(target in candidate for candidate in candidates)
+
+
+def open_dataset_inventory(file_path: Path, variable: str) -> tuple[str, list[str], dict[str, int]]:
+    """Open a CMOR file and inspect the target data variable dimensions."""
+    with xr.open_dataset(file_path, decode_times=False) as dataset:
+        if variable in dataset.data_vars:
+            data_var = variable
+        else:
+            candidates = [
+                name
+                for name in dataset.data_vars
+                if not name.endswith("_bnds") and name not in {"time_bnds", "lat_bnds", "lon_bnds"}
+            ]
+            if not candidates:
+                raise ValueError(f"No data variables found in {file_path}")
+            data_var = candidates[0]
+        array = dataset[data_var]
+        dims = list(array.dims)
+        sizes = {dim: int(array.sizes[dim]) for dim in array.dims}
+    return data_var, dims, sizes
+
+
+def scan_output_tree(
+    cmip_root: Path,
+    *,
+    model: str,
+    experiment: str,
+    frequency: str,
+    expected_variables: set[str],
+    ensemble_member: str | None,
+    institution_id: str | None,
+    resolution: str | None,
+) -> tuple[dict[str, list[Path]], list[ProducedFileRecord], list[dict[str, str]]]:
+    """Scan the CMIP7 tree and inventory produced files for the selected subset."""
+    produced: dict[str, list[Path]] = defaultdict(list)
+    inventory: list[ProducedFileRecord] = []
+    inspection_errors: list[dict[str, str]] = []
+
+    pattern = cmip_root.glob(f"CMIP/*/{model}/{experiment}/*/glb/{frequency}/*/*/*/*.nc")
+    for file_path in sorted(pattern):
+        relative = file_path.relative_to(cmip_root)
+        parts = relative.parts
+        if len(parts) < 11:
+            logger.debug("Skipping unexpected output path layout: %s", file_path)
+            continue
+
+        _, consortium, path_model, path_experiment, path_ensemble, region, path_frequency, variable, dimension_folder, grid_type, _ = parts[:11]
+
+        if institution_id and consortium != institution_id:
+            continue
+        if ensemble_member and path_ensemble != ensemble_member:
+            continue
+        if expected_variables and variable not in expected_variables:
+            continue
+        if not path_matches_resolution(resolution, dimension_folder, grid_type, file_path.name):
+            continue
+
+        produced[variable].append(file_path)
+        try:
+            data_var, dims, sizes = open_dataset_inventory(file_path, variable)
+        except Exception as exc:  # pylint: disable=broad-except
+            inspection_errors.append({
+                "variable": variable,
+                "path": str(file_path),
+                "error": repr(exc),
+            })
+            continue
+
+        inventory.append(
+            ProducedFileRecord(
+                variable=variable,
+                consortium=consortium,
+                model=path_model,
+                experiment=path_experiment,
+                ensemble_member=path_ensemble,
+                region=region,
+                frequency=path_frequency,
+                dimension_folder=dimension_folder,
+                grid_type=grid_type,
+                file_path=str(file_path),
+                data_var=data_var,
+                dims=dims,
+                sizes=sizes,
+            )
+        )
+    return produced, inventory, inspection_errors
+
+
+def summarize_dimension_inventory(inventory: list[ProducedFileRecord]) -> list[dict[str, Any]]:
+    """Collapse file-level inventory into one summary row per variable."""
+    grouped: dict[str, dict[str, set[str] | list[dict[str, Any]]]] = {}
+    for record in inventory:
+        bucket = grouped.setdefault(
+            record.variable,
+            {
+                "dims": set(),
+                "dimension_folders": set(),
+                "grid_types": set(),
+                "data_vars": set(),
+                "sample_sizes": [],
+                "sample_path": record.file_path,
+            },
+        )
+        bucket["dims"].add(", ".join(record.dims))
+        bucket["dimension_folders"].add(record.dimension_folder)
+        bucket["grid_types"].add(record.grid_type)
+        bucket["data_vars"].add(record.data_var)
+        if len(bucket["sample_sizes"]) < 3:
+            bucket["sample_sizes"].append(record.sizes)
+
+    summary = []
+    for variable in sorted(grouped):
+        item = grouped[variable]
+        summary.append(
+            {
+                "variable": variable,
+                "dims": sorted(item["dims"]),
+                "dimension_folders": sorted(item["dimension_folders"]),
+                "grid_types": sorted(item["grid_types"]),
+                "data_vars": sorted(item["data_vars"]),
+                "sample_sizes": item["sample_sizes"],
+                "sample_path": item["sample_path"],
+            }
+        )
+    return summary
+
+
+def write_json_report(report: dict[str, Any], output_path: Path) -> None:
+    """Write the main validation report as JSON."""
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def write_csv_rows(rows: list[dict[str, Any]], output_path: Path) -> None:
+    """Write a homogeneous list of dict rows to CSV."""
+    if not rows:
+        output_path.write_text("", encoding="utf-8")
+        return
+    fieldnames = sorted({field for row in rows for field in row})
+    with open(output_path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_markdown_summary(report: dict[str, Any], output_path: Path) -> None:
+    """Write a concise markdown summary."""
+    lines = [
+        "# CMOR Validation Summary",
+        "",
+        f"- Model: {report['scope']['model']}",
+        f"- Realm: {report['scope']['realm']}",
+        f"- Experiment: {report['scope']['experiment']}",
+        f"- Frequency: {report['scope']['frequency']}",
+        f"- Expected variables: {report['counts']['expected_variables']}",
+        f"- Produced variables: {report['counts']['produced_variables']}",
+        f"- Variables with log errors: {report['counts']['variables_with_log_errors']}",
+        f"- Missing variables: {report['counts']['missing_variables']}",
+        "",
+        "## Variables With Log Errors",
+        "",
+    ]
+    for variable in report["variables_with_log_errors"]:
+        lines.append(f"- {variable}")
+    lines.extend(["", "## Missing Variables", ""])
+    for variable in report["expected_but_not_produced"]:
+        lines.append(f"- {variable}")
+    lines.extend(["", "## Produced Variable Inventory", ""])
+    for item in report["dimension_inventory"]:
+        dims = "; ".join(item["dims"])
+        grids = ", ".join(item["grid_types"])
+        lines.append(f"- {item['variable']}: dims={dims}; grids={grids}")
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _open_variable_timeseries(file_paths: list[Path], variable: str) -> xr.DataArray | None:
+    """Open a variable across files and reduce it to a 1D time series if possible."""
+    if not file_paths:
+        return None
+    with xr.open_mfdataset(file_paths, combine="by_coords", decode_times=True) as dataset:
+        data_var = variable if variable in dataset.data_vars else list(dataset.data_vars)[0]
+        array = dataset[data_var]
+        if "time" not in array.dims:
+            return None
+        reduce_dims = [dim for dim in array.dims if dim != "time" and not dim.endswith("bnds")]
+        if reduce_dims:
+            array = array.mean(dim=reduce_dims, skipna=True)
+        return array.load()
+
+
+def _open_variable_map(file_paths: list[Path], variable: str) -> xr.DataArray | None:
+    """Open a variable across files and reduce it to a 2D spatial field if possible."""
+    if not file_paths:
+        return None
+    with xr.open_mfdataset(file_paths, combine="by_coords", decode_times=True) as dataset:
+        data_var = variable if variable in dataset.data_vars else list(dataset.data_vars)[0]
+        array = dataset[data_var]
+        if "time" in array.dims:
+            array = array.mean(dim="time", skipna=True)
+        spatial_dims = [
+            dim
+            for dim in array.dims
+            if dim.lower() in {"lat", "lon", "latitude", "longitude", "xh", "yh", "i", "j"}
+        ]
+        if len(spatial_dims) != 2:
+            return None
+        extra_dims = [dim for dim in array.dims if dim not in spatial_dims]
+        if extra_dims:
+            array = array.isel({dim: 0 for dim in extra_dims})
+        return array.load()
+
+
+def create_timeseries_plots(
+    produced_files: dict[str, list[Path]],
+    plot_dir: Path,
+    max_plots: int,
+) -> list[str]:
+    """Create paginated composite mean time-series plots."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        logger.warning("matplotlib is not available; skipping time-series plots")
+        return []
+
+    plotted = []
+    variables = sorted(produced_files)[:max_plots]
+    if not variables:
+        return plotted
+
+    page_size = 9
+    for page_index in range(0, len(variables), page_size):
+        page_variables = variables[page_index : page_index + page_size]
+        fig, axes = plt.subplots(3, 3, figsize=(15, 11), squeeze=False)
+        for axis, variable in zip(axes.flat, page_variables):
+            series = _open_variable_timeseries(produced_files[variable], variable)
+            if series is None:
+                axis.set_title(variable)
+                axis.text(0.5, 0.5, "No plottable time series", ha="center", va="center")
+                axis.set_axis_off()
+                continue
+            axis.plot(series["time"].values, series.values, linewidth=1.0)
+            axis.set_title(variable)
+            axis.tick_params(axis="x", rotation=30)
+        for axis in axes.flat[len(page_variables) :]:
+            axis.set_axis_off()
+        fig.tight_layout()
+        output_path = plot_dir / f"timeseries_composite_{page_index // page_size + 1:02d}.png"
+        fig.savefig(output_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        plotted.append(str(output_path))
+    return plotted
+
+
+def create_map_plots(
+    produced_files: dict[str, list[Path]],
+    plot_dir: Path,
+    max_plots: int,
+) -> list[str]:
+    """Create per-variable time-mean map plots where the data shape allows it."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        logger.warning("matplotlib is not available; skipping map plots")
+        return []
+
+    plotted = []
+    for variable in sorted(produced_files)[:max_plots]:
+        field = _open_variable_map(produced_files[variable], variable)
+        if field is None:
+            continue
+        fig, axis = plt.subplots(figsize=(8, 4.5))
+        field.plot(ax=axis)
+        axis.set_title(f"{variable} time-mean")
+        output_path = plot_dir / f"map_{variable}.png"
+        fig.savefig(output_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        plotted.append(str(output_path))
+    return plotted
+
+
+def build_report(
+    args: argparse.Namespace,
+    yaml_path: Path,
+    expected_variables: list[str],
+    log_records: dict[str, list[LogRecord]],
+    produced_files: dict[str, list[Path]],
+    dimension_inventory: list[dict[str, Any]],
+    inspection_errors: list[dict[str, str]],
+    plot_outputs: dict[str, list[str]],
+) -> dict[str, Any]:
+    """Build the structured validation report payload."""
+    variables_with_log_errors = sorted(
+        variable
+        for variable, records in log_records.items()
+        if any(record.has_error for record in records)
+    )
+    produced_variables = sorted(produced_files)
+    expected_but_not_produced = sorted(set(expected_variables) - set(produced_variables))
+    flattened_log_records = [asdict(record) for records in log_records.values() for record in records]
+
+    return {
+        "scope": {
+            "model": args.model,
+            "realm": args.realm,
+            "experiment": args.experiment,
+            "frequency": args.frequency,
+            "resolution": args.resolution,
+            "ensemble_member": args.ensemble_member,
+            "institution_id": args.institution_id,
+            "root_output_path": str(Path(args.root_output_path).expanduser().resolve()),
+            "yaml_path": str(yaml_path),
+        },
+        "counts": {
+            "expected_variables": len(expected_variables),
+            "produced_variables": len(produced_variables),
+            "variables_with_log_errors": len(variables_with_log_errors),
+            "missing_variables": len(expected_but_not_produced),
+            "inspection_errors": len(inspection_errors),
+        },
+        "expected_variables": expected_variables,
+        "variables_with_log_errors": variables_with_log_errors,
+        "expected_but_not_produced": expected_but_not_produced,
+        "produced_variables": produced_variables,
+        "dimension_inventory": dimension_inventory,
+        "log_records": flattened_log_records,
+        "inspection_errors": inspection_errors,
+        "plots": plot_outputs,
+    }
+
+
+def print_summary(report: dict[str, Any]) -> None:
+    """Print a concise terminal summary."""
+    print(
+        f"Validated {report['counts']['expected_variables']} expected variables; "
+        f"found {report['counts']['produced_variables']} produced, "
+        f"{report['counts']['variables_with_log_errors']} with log errors, "
+        f"{report['counts']['missing_variables']} missing."
+    )
+    if report["variables_with_log_errors"]:
+        print("Variables with log errors:")
+        for variable in report["variables_with_log_errors"]:
+            print(f"  - {variable}")
+    if report["expected_but_not_produced"]:
+        print("Expected but not produced:")
+        for variable in report["expected_but_not_produced"]:
+            print(f"  - {variable}")
+
+
+def main() -> int:
+    """Run the CMOR output validation workflow."""
+    args = parse_args()
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    cmip_root = resolve_cmip_root(args.root_output_path)
+    logs_dir = resolve_logs_dir(args.root_output_path, cmip_root)
+    report_dir = Path(args.report_dir).expanduser().resolve() if args.report_dir else default_report_dir(args)
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    yaml_path = get_yaml_path(args.model, args.realm, args.custom_yaml)
+    yaml_variables = load_yaml_variables(yaml_path)
+    requested_variables = get_requested_variables(args.realm, args.experiment, args.frequency)
+    expected_variables = filter_expected_variables(yaml_variables, requested_variables, args.variables)
+    expected_variable_set = set(expected_variables)
+
+    log_records = collect_log_records(logs_dir, expected_variable_set)
+    produced_files, inventory_records, inspection_errors = scan_output_tree(
+        cmip_root,
+        model=args.model,
+        experiment=args.experiment,
+        frequency=args.frequency,
+        expected_variables=expected_variable_set,
+        ensemble_member=args.ensemble_member,
+        institution_id=args.institution_id,
+        resolution=args.resolution,
+    )
+    dimension_inventory = summarize_dimension_inventory(inventory_records)
+
+    plot_outputs = {"timeseries": [], "maps": []}
+    if args.plot_timeseries or args.plot_maps:
+        plot_dir = Path(args.plot_dir).expanduser().resolve() if args.plot_dir else report_dir / "plots"
+        plot_dir.mkdir(parents=True, exist_ok=True)
+        if args.plot_timeseries:
+            plot_outputs["timeseries"] = create_timeseries_plots(produced_files, plot_dir, args.max_plots)
+        if args.plot_maps:
+            plot_outputs["maps"] = create_map_plots(produced_files, plot_dir, args.max_plots)
+
+    report = build_report(
+        args,
+        yaml_path,
+        expected_variables,
+        log_records,
+        produced_files,
+        dimension_inventory,
+        inspection_errors,
+        plot_outputs,
+    )
+
+    write_json_report(report, report_dir / "validation_summary.json")
+    write_csv_rows(report["log_records"], report_dir / "log_records.csv")
+    write_csv_rows(
+        [{"variable": variable} for variable in report["expected_but_not_produced"]],
+        report_dir / "missing_variables.csv",
+    )
+    write_csv_rows(report["dimension_inventory"], report_dir / "dimension_inventory.csv")
+    write_csv_rows(report["inspection_errors"], report_dir / "inspection_errors.csv")
+    write_markdown_summary(report, report_dir / "validation_summary.md")
+
+    print_summary(report)
+
+    if args.strict and (
+        report["variables_with_log_errors"] or report["expected_but_not_produced"]
+    ):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_cmor_output.py
+++ b/scripts/validate_cmor_output.py
@@ -196,13 +196,13 @@ def canonical_realm(realm: str) -> str:
 def resolve_cmip_root(root_output_path: str | Path) -> Path:
     """Resolve the CMIP7 root directory from either a parent or direct path."""
     root = Path(root_output_path).expanduser().resolve()
-    if root.name == "CMIP7" and (root / "CMIP").is_dir():
+    if (root / "CMIP").is_dir():
         return root
     cmip_root = root / "CMIP7"
-    if cmip_root.is_dir() and (cmip_root / "CMIP").is_dir():
+    if (cmip_root / "CMIP").is_dir():
         return cmip_root
     raise FileNotFoundError(
-        f"Could not locate CMIP7/CMIP under {root}. Expected either {root / 'CMIP7'} or a direct CMIP7 path."
+        f"Could not locate CMIP output under {root}. Expected either {root / 'CMIP7' / 'CMIP'} or {root / 'CMIP'}."
     )
 
 

--- a/scripts/validate_cmor_output.py
+++ b/scripts/validate_cmor_output.py
@@ -272,7 +272,7 @@ def get_requested_variables(
         frequency,
     )
     content_dic = dt.get_transformed_content()
-    print(content_dic)
+    logger.debug(content_dic)
     data_request = dr.DataRequest.from_separated_inputs(**content_dic)
     cmip_vars = data_request.find_variables(
         skip_if_missing=False,
@@ -420,16 +420,16 @@ def scan_output_tree(
             _,
         ) = parts[:11]
         if institution_id and consortium != institution_id:
-            print("Skipping due to institution_id filter: %s", institution_id)
+            logger.debug("Skipping due to institution_id filter: %s", institution_id)
             continue
         if ensemble_member and path_ensemble != ensemble_member:
-            print("Skipping due to ensemble filter: %s", ensemble_member)
+            logger.debug("Skipping due to ensemble filter: %s", ensemble_member)
             continue
         if (
             expected_variables
             and f"{variable}_{dimension_folder}" not in expected_variables
         ):
-            print("Skipping due to expected_variables filter: %s", variable)
+            logger.debug("Skipping due to expected_variables filter: %s", variable)
             continue
         if not path_matches_resolution(
             resolution, dimension_folder, grid_type, file_path.name

--- a/scripts/validate_cmor_output.py
+++ b/scripts/validate_cmor_output.py
@@ -434,7 +434,6 @@ def scan_output_tree(
             grid_type,
             _,
         ) = parts[:11]
-
         if institution_id and consortium != institution_id:
             print("Skipping due to institution_id filter: %s", institution_id)
             continue

--- a/scripts/validate_cmor_output.py
+++ b/scripts/validate_cmor_output.py
@@ -23,6 +23,7 @@ import json
 import logging
 import re
 import sys
+import glob
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -33,23 +34,13 @@ import yaml
 
 from cmip7_prep.mapping_compat import packaged_mapping_resource
 
+from cmor_driver import REALM_YAML_MAP
 
 logger = logging.getLogger("cmip7_prep.validate_cmor_output")
 
-
-REALM_YAML_MAP = {
-    "noresm": {
-        "atmos": "noresm_to_cmip7_atmos.yaml",
-        "land": "noresm_to_cmip7_land.yaml",
-        "seaIce": "noresm_to_cmip7_seaice.yaml",
-    },
-    "cesm": {
-        "atmos": "cesm_to_cmip7_atmos.yaml",
-        "land": "cesm_to_cmip7_land.yaml",
-        "landIce": "cesm_to_cmip7_landice.yaml",
-        "seaIce": "cesm_to_cmip7_seaice.yaml",
-        "ocean": "cesm_to_cmip7_ocean.yaml",
-    },
+MODEL_NAMING_MAPS = {
+    "noresm": ["NCC", "NorESM3"],
+    "cesm": ["NCAR", "CESM3"],
 }
 
 CANONICAL_REALM_MAP = {
@@ -121,8 +112,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--experiment",
-        required=True,
-        help="Experiment name to validate",
+        type=str,
+        default="piControl",
+        help="Experiment name to validate (Default piControl)",
     )
     parser.add_argument(
         "--frequency",
@@ -144,11 +136,6 @@ def parse_args() -> argparse.Namespace:
         "--ensemble-member",
         default=None,
         help="Optional ensemble member filter",
-    )
-    parser.add_argument(
-        "--institution-id",
-        default=None,
-        help="Optional consortium/institution segment filter in the CMIP7 path",
     )
     parser.add_argument(
         "--custom-yaml",
@@ -258,7 +245,9 @@ def load_yaml_variables(yaml_path: Path) -> dict[str, dict[str, Any]]:
         payload = yaml.safe_load(handle) or {}
     variables = payload.get("variables")
     if not isinstance(variables, dict):
-        raise ValueError(f"Unsupported YAML structure in {yaml_path}: expected top-level variables dict")
+        raise ValueError(
+            f"Unsupported YAML structure in {yaml_path}: expected top-level variables dict"
+        )
     return variables
 
 
@@ -284,13 +273,14 @@ def get_requested_variables(
         frequency,
     )
     content_dic = dt.get_transformed_content()
+    print(content_dic)
     data_request = dr.DataRequest.from_separated_inputs(**content_dic)
     cmip_vars = data_request.find_variables(
         skip_if_missing=False,
         operation="all",
         cmip7_frequency=frequency,
         modelling_realm=realm,
-        experiment=experiment,
+        # experiment=experiment,
     )
     return {var.branded_variable_name.name for var in cmip_vars}
 
@@ -336,7 +326,9 @@ def parse_log_file(log_path: Path) -> LogRecord | None:
     )
 
 
-def collect_log_records(log_dir: Path, expected_variables: set[str]) -> dict[str, list[LogRecord]]:
+def collect_log_records(
+    log_dir: Path, expected_variables: set[str]
+) -> dict[str, list[LogRecord]]:
     """Collect log records for variables that belong to the selected subset."""
     records: dict[str, list[LogRecord]] = defaultdict(list)
     if not log_dir.is_dir():
@@ -366,7 +358,9 @@ def path_matches_resolution(
     return any(target in candidate for candidate in candidates)
 
 
-def open_dataset_inventory(file_path: Path, variable: str) -> tuple[str, list[str], dict[str, int]]:
+def open_dataset_inventory(
+    file_path: Path, variable: str
+) -> tuple[str, list[str], dict[str, int]]:
     """Open a CMOR file and inspect the target data variable dimensions."""
     with xr.open_dataset(file_path, decode_times=False) as dataset:
         if variable in dataset.data_vars:
@@ -375,7 +369,8 @@ def open_dataset_inventory(file_path: Path, variable: str) -> tuple[str, list[st
             candidates = [
                 name
                 for name in dataset.data_vars
-                if not name.endswith("_bnds") and name not in {"time_bnds", "lat_bnds", "lon_bnds"}
+                if not name.endswith("_bnds")
+                and name not in {"time_bnds", "lat_bnds", "lon_bnds"}
             ]
             if not candidates:
                 raise ValueError(f"No data variables found in {file_path}")
@@ -394,42 +389,81 @@ def scan_output_tree(
     frequency: str,
     expected_variables: set[str],
     ensemble_member: str | None,
-    institution_id: str | None,
     resolution: str | None,
 ) -> tuple[dict[str, list[Path]], list[ProducedFileRecord], list[dict[str, str]]]:
     """Scan the CMIP7 tree and inventory produced files for the selected subset."""
     produced: dict[str, list[Path]] = defaultdict(list)
     inventory: list[ProducedFileRecord] = []
     inspection_errors: list[dict[str, str]] = []
-
-    pattern = cmip_root.glob(f"CMIP/*/{model}/{experiment}/*/glb/{frequency}/*/*/*/*.nc")
+    print(cmip_root)
+    institution_id = MODEL_NAMING_MAPS[model][0]
+    print(
+        f"{cmip_root}/CMIP/{institution_id}/{MODEL_NAMING_MAPS[model][1]}/{experiment}/*/glb/{frequency}/*/*/*/*.nc"
+    )
+    print(
+        glob.glob(
+            f"{cmip_root}/CMIP/{institution_id}/{MODEL_NAMING_MAPS[model][1]}/{experiment}/*/glb/{frequency}/*/*/*/*.nc"
+        )
+    )
+    pattern = cmip_root.glob(
+        f"CMIP/{institution_id}/{MODEL_NAMING_MAPS[model][1]}/{experiment}/*/glb/{frequency}/*/*/*/*.nc"
+    )
+    # print(list(pattern))
+    # sys.exit(4)
+    print(expected_variables)
+    # sys.exit(4)
     for file_path in sorted(pattern):
         relative = file_path.relative_to(cmip_root)
+        print(relative)
+        # sys.exit(4)
         parts = relative.parts
         if len(parts) < 11:
             logger.debug("Skipping unexpected output path layout: %s", file_path)
             continue
 
-        _, consortium, path_model, path_experiment, path_ensemble, region, path_frequency, variable, dimension_folder, grid_type, _ = parts[:11]
+        (
+            _,
+            consortium,
+            path_model,
+            path_experiment,
+            path_ensemble,
+            region,
+            path_frequency,
+            variable,
+            dimension_folder,
+            grid_type,
+            _,
+        ) = parts[:11]
 
         if institution_id and consortium != institution_id:
+            print("Skipping due to institution_id filter: %s", institution_id)
             continue
         if ensemble_member and path_ensemble != ensemble_member:
+            print("Skipping due to ensemble filter: %s", ensemble_member)
             continue
-        if expected_variables and variable not in expected_variables:
+        if (
+            expected_variables
+            and f"{variable}_{dimension_folder}" not in expected_variables
+        ):
+            print("Skipping due to expected_variables filter: %s", variable)
             continue
-        if not path_matches_resolution(resolution, dimension_folder, grid_type, file_path.name):
+        if not path_matches_resolution(
+            resolution, dimension_folder, grid_type, file_path.name
+        ):
+            print("Skipping due to resolution filter: %s", resolution)
             continue
 
         produced[variable].append(file_path)
         try:
             data_var, dims, sizes = open_dataset_inventory(file_path, variable)
         except Exception as exc:  # pylint: disable=broad-except
-            inspection_errors.append({
-                "variable": variable,
-                "path": str(file_path),
-                "error": repr(exc),
-            })
+            inspection_errors.append(
+                {
+                    "variable": variable,
+                    "path": str(file_path),
+                    "error": repr(exc),
+                }
+            )
             continue
 
         inventory.append(
@@ -452,7 +486,9 @@ def scan_output_tree(
     return produced, inventory, inspection_errors
 
 
-def summarize_dimension_inventory(inventory: list[ProducedFileRecord]) -> list[dict[str, Any]]:
+def summarize_dimension_inventory(
+    inventory: list[ProducedFileRecord],
+) -> list[dict[str, Any]]:
     """Collapse file-level inventory into one summary row per variable."""
     grouped: dict[str, dict[str, set[str] | list[dict[str, Any]]]] = {}
     for record in inventory:
@@ -493,7 +529,9 @@ def summarize_dimension_inventory(inventory: list[ProducedFileRecord]) -> list[d
 
 def write_json_report(report: dict[str, Any], output_path: Path) -> None:
     """Write the main validation report as JSON."""
-    output_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+    )
 
 
 def write_csv_rows(rows: list[dict[str, Any]], output_path: Path) -> None:
@@ -538,16 +576,24 @@ def write_markdown_summary(report: dict[str, Any], output_path: Path) -> None:
     output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def _open_variable_timeseries(file_paths: list[Path], variable: str) -> xr.DataArray | None:
+def _open_variable_timeseries(
+    file_paths: list[Path], variable: str
+) -> xr.DataArray | None:
     """Open a variable across files and reduce it to a 1D time series if possible."""
     if not file_paths:
         return None
-    with xr.open_mfdataset(file_paths, combine="by_coords", decode_times=True) as dataset:
-        data_var = variable if variable in dataset.data_vars else list(dataset.data_vars)[0]
+    with xr.open_mfdataset(
+        file_paths, combine="by_coords", decode_times=True
+    ) as dataset:
+        data_var = (
+            variable if variable in dataset.data_vars else list(dataset.data_vars)[0]
+        )
         array = dataset[data_var]
         if "time" not in array.dims:
             return None
-        reduce_dims = [dim for dim in array.dims if dim != "time" and not dim.endswith("bnds")]
+        reduce_dims = [
+            dim for dim in array.dims if dim != "time" and not dim.endswith("bnds")
+        ]
         if reduce_dims:
             array = array.mean(dim=reduce_dims, skipna=True)
         return array.load()
@@ -557,15 +603,20 @@ def _open_variable_map(file_paths: list[Path], variable: str) -> xr.DataArray | 
     """Open a variable across files and reduce it to a 2D spatial field if possible."""
     if not file_paths:
         return None
-    with xr.open_mfdataset(file_paths, combine="by_coords", decode_times=True) as dataset:
-        data_var = variable if variable in dataset.data_vars else list(dataset.data_vars)[0]
+    with xr.open_mfdataset(
+        file_paths, combine="by_coords", decode_times=True
+    ) as dataset:
+        data_var = (
+            variable if variable in dataset.data_vars else list(dataset.data_vars)[0]
+        )
         array = dataset[data_var]
         if "time" in array.dims:
             array = array.mean(dim="time", skipna=True)
         spatial_dims = [
             dim
             for dim in array.dims
-            if dim.lower() in {"lat", "lon", "latitude", "longitude", "xh", "yh", "i", "j"}
+            if dim.lower()
+            in {"lat", "lon", "latitude", "longitude", "xh", "yh", "i", "j"}
         ]
         if len(spatial_dims) != 2:
             return None
@@ -600,7 +651,9 @@ def create_timeseries_plots(
             series = _open_variable_timeseries(produced_files[variable], variable)
             if series is None:
                 axis.set_title(variable)
-                axis.text(0.5, 0.5, "No plottable time series", ha="center", va="center")
+                axis.text(
+                    0.5, 0.5, "No plottable time series", ha="center", va="center"
+                )
                 axis.set_axis_off()
                 continue
             axis.plot(series["time"].values, series.values, linewidth=1.0)
@@ -609,7 +662,9 @@ def create_timeseries_plots(
         for axis in axes.flat[len(page_variables) :]:
             axis.set_axis_off()
         fig.tight_layout()
-        output_path = plot_dir / f"timeseries_composite_{page_index // page_size + 1:02d}.png"
+        output_path = (
+            plot_dir / f"timeseries_composite_{page_index // page_size + 1:02d}.png"
+        )
         fig.savefig(output_path, dpi=150, bbox_inches="tight")
         plt.close(fig)
         plotted.append(str(output_path))
@@ -660,8 +715,12 @@ def build_report(
         if any(record.has_error for record in records)
     )
     produced_variables = sorted(produced_files)
-    expected_but_not_produced = sorted(set(expected_variables) - set(produced_variables))
-    flattened_log_records = [asdict(record) for records in log_records.values() for record in records]
+    expected_but_not_produced = sorted(
+        set(expected_variables) - set(produced_variables)
+    )
+    flattened_log_records = [
+        asdict(record) for records in log_records.values() for record in records
+    ]
 
     return {
         "scope": {
@@ -671,7 +730,7 @@ def build_report(
             "frequency": args.frequency,
             "resolution": args.resolution,
             "ensemble_member": args.ensemble_member,
-            "institution_id": args.institution_id,
+            "institution_id": MODEL_NAMING_MAPS.get(args.model, [None, None])[0],
             "root_output_path": str(Path(args.root_output_path).expanduser().resolve()),
             "yaml_path": str(yaml_path),
         },
@@ -721,13 +780,21 @@ def main() -> int:
 
     cmip_root = resolve_cmip_root(args.root_output_path)
     logs_dir = resolve_logs_dir(args.root_output_path, cmip_root)
-    report_dir = Path(args.report_dir).expanduser().resolve() if args.report_dir else default_report_dir(args)
+    report_dir = (
+        Path(args.report_dir).expanduser().resolve()
+        if args.report_dir
+        else default_report_dir(args)
+    )
     report_dir.mkdir(parents=True, exist_ok=True)
 
     yaml_path = get_yaml_path(args.model, args.realm, args.custom_yaml)
     yaml_variables = load_yaml_variables(yaml_path)
-    requested_variables = get_requested_variables(args.realm, args.experiment, args.frequency)
-    expected_variables = filter_expected_variables(yaml_variables, requested_variables, args.variables)
+    requested_variables = get_requested_variables(
+        args.realm, args.experiment, args.frequency
+    )
+    expected_variables = filter_expected_variables(
+        yaml_variables, requested_variables, args.variables
+    )
     expected_variable_set = set(expected_variables)
 
     log_records = collect_log_records(logs_dir, expected_variable_set)
@@ -738,19 +805,26 @@ def main() -> int:
         frequency=args.frequency,
         expected_variables=expected_variable_set,
         ensemble_member=args.ensemble_member,
-        institution_id=args.institution_id,
         resolution=args.resolution,
     )
     dimension_inventory = summarize_dimension_inventory(inventory_records)
 
     plot_outputs = {"timeseries": [], "maps": []}
     if args.plot_timeseries or args.plot_maps:
-        plot_dir = Path(args.plot_dir).expanduser().resolve() if args.plot_dir else report_dir / "plots"
+        plot_dir = (
+            Path(args.plot_dir).expanduser().resolve()
+            if args.plot_dir
+            else report_dir / "plots"
+        )
         plot_dir.mkdir(parents=True, exist_ok=True)
         if args.plot_timeseries:
-            plot_outputs["timeseries"] = create_timeseries_plots(produced_files, plot_dir, args.max_plots)
+            plot_outputs["timeseries"] = create_timeseries_plots(
+                produced_files, plot_dir, args.max_plots
+            )
         if args.plot_maps:
-            plot_outputs["maps"] = create_map_plots(produced_files, plot_dir, args.max_plots)
+            plot_outputs["maps"] = create_map_plots(
+                produced_files, plot_dir, args.max_plots
+            )
 
     report = build_report(
         args,
@@ -769,7 +843,9 @@ def main() -> int:
         [{"variable": variable} for variable in report["expected_but_not_produced"]],
         report_dir / "missing_variables.csv",
     )
-    write_csv_rows(report["dimension_inventory"], report_dir / "dimension_inventory.csv")
+    write_csv_rows(
+        report["dimension_inventory"], report_dir / "dimension_inventory.csv"
+    )
     write_csv_rows(report["inspection_errors"], report_dir / "inspection_errors.csv")
     write_markdown_summary(report, report_dir / "validation_summary.md")
 

--- a/scripts/validate_cmor_output.py
+++ b/scripts/validate_cmor_output.py
@@ -279,7 +279,7 @@ def get_requested_variables(
         operation="all",
         cmip7_frequency=frequency,
         modelling_realm=realm,
-        # experiment=experiment,
+        experiment=experiment,
     )
     return {var.branded_variable_name.name for var in cmip_vars}
 
@@ -387,8 +387,8 @@ def scan_output_tree(
     experiment: str,
     frequency: str,
     expected_variables: set[str],
-    ensemble_member: str | None,
-    resolution: str | None,
+    ensemble_member: str | None = None,
+    resolution: str | None = None,
 ) -> tuple[dict[str, list[Path]], list[ProducedFileRecord], list[dict[str, str]]]:
     """Scan the CMIP7 tree and inventory produced files for the selected subset."""
     produced: dict[str, list[Path]] = defaultdict(list)

--- a/src/cmip7_prep/mapping_compat.py
+++ b/src/cmip7_prep/mapping_compat.py
@@ -376,6 +376,23 @@ class Mapping:
             return _to_varconfig(cmip_name, raw, freq=effective_freq).as_cfg()
         return self._vars[cmip_name].as_cfg()
 
+    def iter_variable_names(self, freq: Optional[str] = None) -> List[str]:
+        """Return top-level mapping variable names in YAML order.
+
+        When ``freq`` is provided, variables whose sources are only tagged for
+        other frequencies are excluded. Untagged sources remain eligible for
+        all frequencies.
+        """
+        effective_freq = freq if freq is not None else self.default_freq
+        names = []
+        for cmip_name, internal_keys in self._variant_keys.items():
+            if any(
+                _mapping_entry_supports_frequency(self._raw.get(key), effective_freq)
+                for key in internal_keys
+            ):
+                names.append(cmip_name)
+        return names
+
     def realize(
         self, ds: xr.Dataset, cmip_name: str, freq: Optional[str] = None
     ) -> xr.DataArray:
@@ -494,6 +511,32 @@ def _filter_sources(sources: List[Any], freq: Optional[str]) -> List[Any]:
     if matched:
         return matched + untagged
     return untagged if untagged else sources
+
+
+def _mapping_entry_supports_frequency(
+    cfg: Optional[TMapping[str, Any]], freq: Optional[str]
+) -> bool:
+    """Return whether a raw mapping entry should be considered for *freq*.
+
+    Entries with untagged sources are always eligible. Entries with only
+    tagged sources are eligible only when at least one source matches *freq*.
+    """
+    if cfg is None or freq is None:
+        return True
+    sources = cfg.get("sources")
+    if not isinstance(sources, list) or not sources:
+        return True
+
+    has_tagged_sources = False
+    for item in sources:
+        if not isinstance(item, dict):
+            return True
+        if "freq" not in item:
+            return True
+        has_tagged_sources = True
+        if item.get("freq") == freq:
+            return True
+    return not has_tagged_sources
 
 
 def _to_varconfig(

--- a/src/cmip7_prep/regrid.py
+++ b/src/cmip7_prep/regrid.py
@@ -27,14 +27,12 @@ try:
 except ModuleNotFoundError as e:
     _HAS_DASK = False
 
-#---------------------------------------------------------
+# ---------------------------------------------------------
 # Default NorESM weight maps; override via function args.
-#---------------------------------------------------------
+# ---------------------------------------------------------
 
 INPUTDATA_DIR_noresm = Path("/nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/")
-DEFAULT_CONS_MAP_NE30_noresm = Path(
-    INPUTDATA_DIR_noresm / "map_ne30pg3_to_1x1_aave.nc"
-)
+DEFAULT_CONS_MAP_NE30_noresm = Path(INPUTDATA_DIR_noresm / "map_ne30pg3_to_1x1_aave.nc")
 DEFAULT_BILIN_MAP_NE30_noresm = Path(
     INPUTDATA_DIR_noresm / "map_ne30pg3_to_1x1_bilin.nc"
 )
@@ -51,9 +49,9 @@ DEFAULT_BILIN_MAP_TNX1V4 = Path(
     INPUTDATA_DIR_noresm / "map_tnx1v4_to_1x1_blin_c260531.nc"
 )
 
-#---------------------------------------------------------
+# ---------------------------------------------------------
 # Default CESM weight maps; override via function args.
-#---------------------------------------------------------
+# ---------------------------------------------------------
 
 INPUTDATA_DIR_cesm = Path("/glade/campaign/cesm/cesmdata/inputdata/")
 DEFAULT_CONS_MAP_NE30_cesm = Path(
@@ -69,9 +67,9 @@ DEFAULT_BILIN_MAP_T232 = Path(
     INPUTDATA_DIR_cesm / "cpl/gridmaps/tx2_3v2/map_t232_TO_1x1d_blin.251023.nc"
 )  # optional bilinear map
 
-#---------------------------------------------------------
+# ---------------------------------------------------------
 # Intensive variables
-#---------------------------------------------------------
+# ---------------------------------------------------------
 
 INTENSIVE_VARS = {
     "tas",
@@ -293,7 +291,9 @@ def _pick_maps(
                 Path(bilinear_map) if bilinear_map else DEFAULT_BILIN_MAP_NE16_noresm
             )
         else:
-            cons = Path(conservative_map) if conservative_map else DEFAULT_CONS_MAP_TNX1V4
+            cons = (
+                Path(conservative_map) if conservative_map else DEFAULT_CONS_MAP_TNX1V4
+            )
             bilin = Path(bilinear_map) if bilinear_map else DEFAULT_BILIN_MAP_TNX1V4
 
     if cons is None and bilin is None:
@@ -477,14 +477,17 @@ def regrid_to_latlon(
 
     var_da = ds_in[varname]  # always a DataArray
 
-    # TODO: handle if the lat, lon coords are already present, but still on the wrong grid
+    # In future: handle if the lat, lon coords are already present, but still on the wrong grid
     # or other changes to the grid should be made.
-    if resolution == 'regular':
+    if resolution == "regular":
         if "lat" in var_da.dims and "lon" in var_da.dims:
-            logger.info("Variable already has 'lat' and 'lon' dims; skipping regridding.")
+            logger.info(
+                "Variable already has 'lat' and 'lon' dims; skipping regridding."
+            )
             return var_da
-        else:
-            raise KeyError(f"regular grid is requested but variable does not have 'lat','lon' dims")
+        raise KeyError(
+            "regular grid is requested but variable does not have 'lat','lon' dims"
+        )
 
     if "ncol" not in var_da.dims and "lndgrid" not in var_da.dims:
         logger.info(
@@ -798,6 +801,8 @@ def _regrid_fx_once(
             lndarea = (ds_native["landfrac"] * ds_native["area"] * 1.0e6).sum(
                 dim=("lat", "lon")
             )
+            logger.debug("Total land area on source grid: %.3e m^2", lndarea.values)
+            out = da
             out.name = "sftlf"
             out.attrs.update(da.attrs)
             out_vars["sftlf"] = out

--- a/src/cmip7_prep/variable_selection.py
+++ b/src/cmip7_prep/variable_selection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from dataclasses import dataclass, field
 from typing import Any, Iterable, List, Tuple
 
@@ -28,10 +29,68 @@ class SyntheticVariable:
     is_synthetic: bool = True
 
 
+def _build_data_request_variable(
+    cmip_name: str,
+    physical_parameter: str | None = None,
+    *,
+    data_request: object | None = None,
+    template_var: object | None = None,
+    freq: str | None = None,
+    realm: str | None = None,
+) -> object | None:
+    """Build a real data-request Variable when a DR context is available."""
+    dr_ref = getattr(template_var, "dr", None) or data_request
+    if dr_ref is None:
+        return None
+
+    variable_cls = type(template_var) if template_var is not None else None
+    if variable_cls is None:
+        try:
+            module = importlib.import_module("data_request_api.query.data_request")
+            variable_cls = module.Variable
+        except (ImportError, AttributeError):
+            return None
+
+    attrs: dict[str, Any] = {
+        "title": cmip_name,
+        "branded_variable_name": NamedEntry(cmip_name),
+        "physical_parameter": NamedEntry(physical_parameter or cmip_name),
+    }
+    if freq is not None:
+        attrs["cmip7_frequency"] = NamedEntry(freq)
+    if realm is not None:
+        attrs["modelling_realm"] = [NamedEntry(realm)]
+
+    synthetic = variable_cls.from_input(
+        dr=dr_ref,
+        id=f"synthetic::{cmip_name}",
+        **attrs,
+    )
+    setattr(synthetic, "is_synthetic", True)
+    return synthetic
+
+
 def build_synthetic_variable(
-    cmip_name: str, physical_parameter: str | None = None
-) -> SyntheticVariable:
-    """Build the minimum variable object needed by the CMOR driver."""
+    cmip_name: str,
+    physical_parameter: str | None = None,
+    *,
+    data_request: object | None = None,
+    template_var: object | None = None,
+    freq: str | None = None,
+    realm: str | None = None,
+) -> object:
+    """Build a synthetic variable, preferring a real DataRequest Variable surface."""
+    data_request_var = _build_data_request_variable(
+        cmip_name,
+        physical_parameter,
+        data_request=data_request,
+        template_var=template_var,
+        freq=freq,
+        realm=realm,
+    )
+    if data_request_var is not None:
+        return data_request_var
+
     branded_name = NamedEntry(cmip_name)
     parameter_name = NamedEntry(physical_parameter or cmip_name)
     return SyntheticVariable(
@@ -45,21 +104,34 @@ def assemble_yaml_defined_cmip_vars(
     mapping: Mapping,
     data_request_vars: Iterable[object],
     *,
+    data_request: object | None = None,
     freq: str | None = None,
+    realm: str | None = None,
 ) -> Tuple[List[object], List[str]]:
     """Assemble variables in mapping order, reusing data-request matches when present."""
     vars_by_name = {}
+    template_var = None
     for var in data_request_vars:
         branded_name = getattr(getattr(var, "branded_variable_name", None), "name", None)
         if branded_name is not None and branded_name not in vars_by_name:
             vars_by_name[branded_name] = var
+        if template_var is None and hasattr(var, "dr") and hasattr(var, "attributes"):
+            template_var = var
 
     resolved = []
     synthesized = []
     for cmip_name in mapping.iter_variable_names(freq=freq):
         existing = vars_by_name.get(cmip_name)
         if existing is None:
-            resolved.append(build_synthetic_variable(cmip_name))
+            resolved.append(
+                build_synthetic_variable(
+                    cmip_name,
+                    data_request=data_request,
+                    template_var=template_var,
+                    freq=freq,
+                    realm=realm,
+                )
+            )
             synthesized.append(cmip_name)
             continue
         resolved.append(existing)

--- a/src/cmip7_prep/variable_selection.py
+++ b/src/cmip7_prep/variable_selection.py
@@ -1,0 +1,66 @@
+"""Helpers for assembling CMIP variable lists from mappings and data-request results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, List, Tuple
+
+from cmip7_prep.mapping_compat import Mapping
+
+
+@dataclass(frozen=True)
+class NamedEntry:
+    """Minimal name wrapper matching the data-request object surface used downstream."""
+
+    name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass
+class SyntheticVariable:
+    """Mapping-backed stand-in for a data-request variable."""
+
+    branded_variable_name: NamedEntry
+    physical_parameter: NamedEntry
+    attributes: dict[str, Any] = field(default_factory=dict)
+    is_synthetic: bool = True
+
+
+def build_synthetic_variable(
+    cmip_name: str, physical_parameter: str | None = None
+) -> SyntheticVariable:
+    """Build the minimum variable object needed by the CMOR driver."""
+    branded_name = NamedEntry(cmip_name)
+    parameter_name = NamedEntry(physical_parameter or cmip_name)
+    return SyntheticVariable(
+        branded_variable_name=branded_name,
+        physical_parameter=parameter_name,
+        attributes={"branded_variable_name": branded_name},
+    )
+
+
+def assemble_yaml_defined_cmip_vars(
+    mapping: Mapping,
+    data_request_vars: Iterable[object],
+    *,
+    freq: str | None = None,
+) -> Tuple[List[object], List[str]]:
+    """Assemble variables in mapping order, reusing data-request matches when present."""
+    vars_by_name = {}
+    for var in data_request_vars:
+        branded_name = getattr(getattr(var, "branded_variable_name", None), "name", None)
+        if branded_name is not None and branded_name not in vars_by_name:
+            vars_by_name[branded_name] = var
+
+    resolved = []
+    synthesized = []
+    for cmip_name in mapping.iter_variable_names(freq=freq):
+        existing = vars_by_name.get(cmip_name)
+        if existing is None:
+            resolved.append(build_synthetic_variable(cmip_name))
+            synthesized.append(cmip_name)
+            continue
+        resolved.append(existing)
+    return resolved, synthesized

--- a/src/cmip7_prep/variable_selection.py
+++ b/src/cmip7_prep/variable_selection.py
@@ -1,4 +1,10 @@
-"""Helpers for assembling CMIP variable lists from mappings and data-request results."""
+"""Helpers for assembling CMIP variable lists from mappings and data-request results.
+
+Purpose mainly to be able to make cmorised variables that are not yet in the data-request, 
+but which are defined in the mapping YAML. cmor_driver.py can use this
+when the run-all-from-yaml argument is true. This expands the usability of cmip7-prep
+so it can be used to generate cmorised output for additional MIPs or project related runs
+"""
 
 from __future__ import annotations
 

--- a/tests/test_mapping_compat.py
+++ b/tests/test_mapping_compat.py
@@ -157,6 +157,39 @@ def test_get_cfg_no_freq_returns_both(
     assert set(cfg["raw_variables"]) == {"siu_d", "siu"}
 
 
+def test_iter_variable_names_respects_frequency(cice_mapping):  # pylint: disable=redefined-outer-name
+    """iter_variable_names keeps entries that support the requested frequency."""
+    assert cice_mapping.iter_variable_names(freq="mon") == ["siu_tavg-u-hxy-si"]
+    assert cice_mapping.iter_variable_names(freq="day") == ["siu_tavg-u-hxy-si"]
+
+
+def test_iter_variable_names_skips_incompatible_frequency(tmp_path):
+    """iter_variable_names excludes entries tagged only for other frequencies."""
+    yaml_str = """
+variables:
+  tas:
+    table: Amon
+    sources:
+      - model_var: T2M
+        freq: mon
+  pr:
+    table: Amon
+    sources:
+      - model_var: PRECT
+        freq: day
+  ps:
+    table: Amon
+    sources:
+      - model_var: PS
+"""
+    path = tmp_path / "freq_filter.yaml"
+    path.write_text(yaml_str)
+    mapping = Mapping(path)
+
+    assert mapping.iter_variable_names(freq="mon") == ["tas", "ps"]
+    assert mapping.iter_variable_names(freq="day") == ["pr", "ps"]
+
+
 def test_realize_mon_picks_correct_var(
     cice_mapping,
 ):  # pylint: disable=redefined-outer-name
@@ -360,3 +393,10 @@ def test_realize_all_non_variant_single_element(
     assert len(results) == 1
     da, _ = results[0]
     assert float(da.mean()) == pytest.approx(1.0)
+
+
+def test_iter_variable_names_variant_entry_stays_visible(
+    siarea_mapping,
+):  # pylint: disable=redefined-outer-name
+    """Variant-backed variables are returned once as their top-level YAML key."""
+    assert siarea_mapping.iter_variable_names(freq="mon") == ["siarea_tavg-u-hm-u"]

--- a/tests/test_validate_cmor_output.py
+++ b/tests/test_validate_cmor_output.py
@@ -1,0 +1,108 @@
+"""Tests for scripts/validate_cmor_output.py."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from validate_cmor_output import (  # pylint: disable=wrong-import-position
+    collect_log_records,
+    parse_log_variable,
+    resolve_cmip_root,
+    scan_output_tree,
+    summarize_dimension_inventory,
+)
+
+
+def test_resolve_cmip_root_accepts_parent(tmp_path):
+    """A parent directory containing CMIP7/CMIP resolves to CMIP7."""
+    cmip_root = tmp_path / "CMIP7" / "CMIP"
+    cmip_root.mkdir(parents=True)
+    assert resolve_cmip_root(tmp_path) == tmp_path / "CMIP7"
+
+
+def test_resolve_cmip_root_accepts_direct_cmip7(tmp_path):
+    """A direct CMIP7 path resolves unchanged."""
+    cmip_root = tmp_path / "CMIP"
+    cmip_root.mkdir(parents=True)
+    assert resolve_cmip_root(tmp_path) == tmp_path
+
+
+def test_parse_log_variable_extracts_variable_name():
+    """CMOR log names carry the branded variable name."""
+    assert parse_log_variable(Path("cmor_20260101T010203Z_tas.log")) == "tas"
+
+
+def test_collect_log_records_filters_to_expected_variables(tmp_path):
+    """Only expected variables should be kept when collecting logs."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "cmor_20260101T010203Z_tas.log").write_text(
+        "ERROR something failed\n", encoding="utf-8"
+    )
+    (log_dir / "cmor_20260101T010203Z_pr.log").write_text(
+        "all good\n", encoding="utf-8"
+    )
+
+    records = collect_log_records(log_dir, {"tas"})
+    assert sorted(records) == ["tas"]
+    assert records["tas"][0].has_error is True
+
+
+def test_scan_output_tree_inventories_dims(tmp_path):
+    """Produced CMOR files should be discovered and their dims inventoried."""
+    file_path = (
+        tmp_path
+        / "CMIP7"
+        / "CMIP"
+        / "NCC"
+        / "noresm"
+        / "piControl"
+        / "r1i1p1f1"
+        / "glb"
+        / "mon"
+        / "tas"
+        / "hxy"
+        / "gr"
+        / "tas_Amon_noresm_piControl_r1i1p1f1_gr_185001-185012.nc"
+    )
+    file_path.parent.mkdir(parents=True)
+    data = xr.Dataset(
+        {
+            "tas": xr.DataArray(
+                np.ones((2, 3, 4), dtype=np.float32),
+                dims=("time", "lat", "lon"),
+                coords={
+                    "time": np.array([0, 1]),
+                    "lat": np.array([-10.0, 0.0, 10.0]),
+                    "lon": np.array([0.0, 90.0, 180.0, 270.0]),
+                },
+            )
+        }
+    )
+    data.to_netcdf(file_path)
+
+    produced, inventory, errors = scan_output_tree(
+        tmp_path / "CMIP7",
+        model="noresm",
+        experiment="piControl",
+        frequency="mon",
+        expected_variables={"tas"},
+        ensemble_member=None,
+        institution_id=None,
+        resolution=None,
+    )
+
+    assert sorted(produced) == ["tas"]
+    assert not errors
+    summary = summarize_dimension_inventory(inventory)
+    assert summary[0]["variable"] == "tas"
+    assert summary[0]["dims"] == ["time, lat, lon"]
+    assert summary[0]["grid_types"] == ["gr"]

--- a/tests/test_validate_cmor_output.py
+++ b/tests/test_validate_cmor_output.py
@@ -30,9 +30,10 @@ def test_resolve_cmip_root_accepts_parent(tmp_path):
 
 def test_resolve_cmip_root_accepts_direct_cmip7(tmp_path):
     """A direct CMIP7 path resolves unchanged."""
-    cmip_root = tmp_path / "CMIP"
+    cmip_root = tmp_path / "CMIP7" / "CMIP"
     cmip_root.mkdir(parents=True)
-    assert resolve_cmip_root(tmp_path) == tmp_path
+    print(resolve_cmip_root(tmp_path))
+    assert resolve_cmip_root(tmp_path) == tmp_path / "CMIP7"
 
 
 def test_parse_log_variable_extracts_variable_name():
@@ -63,7 +64,7 @@ def test_scan_output_tree_inventories_dims(tmp_path):
         / "CMIP7"
         / "CMIP"
         / "NCC"
-        / "noresm"
+        / "NorESM3"
         / "piControl"
         / "r1i1p1f1"
         / "glb"
@@ -94,9 +95,8 @@ def test_scan_output_tree_inventories_dims(tmp_path):
         model="noresm",
         experiment="piControl",
         frequency="mon",
-        expected_variables={"tas"},
+        expected_variables={"tas_hxy"},
         ensemble_member=None,
-        institution_id=None,
         resolution=None,
     )
 

--- a/tests/test_variable_selection.py
+++ b/tests/test_variable_selection.py
@@ -1,0 +1,82 @@
+"""Unit tests for YAML-driven CMIP variable assembly helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from cmip7_prep.mapping_compat import Mapping
+from cmip7_prep.variable_selection import (
+    NamedEntry,
+    assemble_yaml_defined_cmip_vars,
+    build_synthetic_variable,
+)
+
+
+def test_build_synthetic_variable_exposes_driver_surface():
+    """Synthetic variables provide the minimum fields consumed by the driver."""
+    var = build_synthetic_variable("tas")
+
+    assert var.branded_variable_name.name == "tas"
+    assert var.physical_parameter.name == "tas"
+    assert var.attributes["branded_variable_name"].name == "tas"
+    assert var.is_synthetic is True
+
+
+def test_assemble_yaml_defined_cmip_vars_preserves_mapping_order(tmp_path):
+    """Assembly should follow mapping order and reuse real objects when present."""
+    yaml_str = """
+variables:
+  tas:
+    table: Amon
+    sources:
+      - model_var: T2M
+  pr:
+    table: Amon
+    sources:
+      - model_var: PRECT
+"""
+    mapping_path = tmp_path / "mapping.yaml"
+    mapping_path.write_text(yaml_str)
+    mapping = Mapping(mapping_path)
+
+    real_var = SimpleNamespace(
+        branded_variable_name=NamedEntry("pr"),
+        physical_parameter=NamedEntry("precipitation_flux"),
+        attributes={"branded_variable_name": NamedEntry("pr")},
+    )
+
+    resolved, synthesized = assemble_yaml_defined_cmip_vars(
+        mapping,
+        [real_var],
+        freq="mon",
+    )
+
+    assert [var.branded_variable_name.name for var in resolved] == ["tas", "pr"]
+    assert resolved[1] is real_var
+    assert resolved[0].is_synthetic is True
+    assert synthesized == ["tas"]
+
+
+def test_assemble_yaml_defined_cmip_vars_skips_incompatible_frequency(tmp_path):
+    """Assembly should only include mapping variables compatible with the runtime frequency."""
+    yaml_str = """
+variables:
+  tas:
+    table: Amon
+    sources:
+      - model_var: T2M
+        freq: mon
+  pr:
+    table: Amon
+    sources:
+      - model_var: PRECT
+        freq: day
+"""
+    mapping_path = tmp_path / "freq_mapping.yaml"
+    mapping_path.write_text(yaml_str)
+    mapping = Mapping(mapping_path)
+
+    resolved, synthesized = assemble_yaml_defined_cmip_vars(mapping, [], freq="day")
+
+    assert [var.branded_variable_name.name for var in resolved] == ["pr"]
+    assert synthesized == ["pr"]


### PR DESCRIPTION
## Pull request overview

Adds support for assembling/running CMIP variables directly from the YAML mapping (optionally overriding the data request), plus a standalone validator script for checking CMOR output trees and expanded mapping frequency filtering.

**Changes:**
- Introduces `cmip7_prep.variable_selection` helpers to synthesize YAML-defined variables and preserve YAML order when data-request variables are missing.
- Extends `Mapping` with `iter_variable_names(freq=...)` to list YAML variables while respecting source-level frequency tags.
- Adds `scripts/validate_cmor_output.py` and tests to scan produced CMIP7 output, parse CMOR logs, and inventory dimensions; includes small mapping/data updates and minor regrid logging.

### Reviewed changes

Copilot reviewed 10 out of 10 changed files in this pull request and generated 10 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| `scripts/cmor_driver.py` | Adds `--run-all-from-yaml` mode and YAML-driven variable assembly for CMOR runs. |
| `src/cmip7_prep/variable_selection.py` | New helpers to merge YAML mapping variables with data-request results and synthesize missing variables. |
| `src/cmip7_prep/mapping_compat.py` | Adds `iter_variable_names()` and frequency-eligibility helper for YAML entries. |
| `tests/test_variable_selection.py` | Unit tests for YAML-driven variable assembly/synthetic variable surface. |
| `tests/test_mapping_compat.py` | Tests for `iter_variable_names()` frequency filtering and variant visibility. |
| `scripts/validate_cmor_output.py` | New validation CLI to check CMOR logs, missing variables, and dimension inventory of produced files. |
| `tests/test_validate_cmor_output.py` | Tests for validation helpers (root detection, log parsing, output scanning, dimension summary). |
| `src/cmip7_prep/regrid.py` | Formatting tweaks and added debug logging for land-area diagnostic during fx handling. |
| `data/noresm_to_cmip7_land.yaml` | Adds `positive: up` to evap variables; updates grassFracC3 formula to use `sumoverpft(...)`. |
| `data/cmor_dataset_noresm.json` | Adjusts `license_id` formatting (`CC-BY-4.0`). |
</details>




<details>
<summary>Comments suppressed due to low confidence (1)</summary>

**scripts/cmor_driver.py:927**
* `make_cmip_vars_from_full_yaml()` currently prints and immediately `sys.exit(4)`. Even though it's unused, keeping this in a shared script is risky (accidental import/call will terminate the process) and looks like leftover debugging.
```
if __name__ == "__main__":
    args = parse_args()
    if getattr(args, "version", False):
        print(f"cmor_driver.py version: {get_version()}")
        sys.exit(0)
    main()
```
</details>

