### PR TITLE
new cmor 3.15 tooling and and noresm seaice with no regridding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "cmip7-cmor-tables"]
+	path = cmip7-cmor-tables
+	url = https://github.com/NorESMhub/cmip7-cmor-tables.git
+	branch = noresm-dev

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,69 @@
+# Installing cmip7-prep (with cmor 3.15)
+
+This project depends on **CMOR 3.15** and the matching **CMIP7 CMOR tables**.
+CMOR 3.15 is the version that validates against the CMIP7 controlled vocabulary
+(license IDs, `gNNN` grid labels, etc.), so an older CMOR will fail at write time.
+
+## Requirements
+
+- **Python 3.12.** CMOR 3.15 has no conda build for Python 3.13, and the project
+  requires Python < 3.14, so 3.12 is the only workable version.
+- The science stack comes from **conda-forge**; a few extras come from **pip**.
+
+## Steps
+
+### 1. Create the conda environment (science stack + cmor 3.15)
+
+```bash
+conda create --prefix /projects/NS9560K/diagnostics/cmordev_env_312 -c conda-forge \
+  python=3.12 cmor=3.15 xarray numpy dask xesmf cftime pyyaml click pandas geocat-comp
+```
+
+When conda prints its plan, confirm the `cmor` line shows `3.15.x` with a `py312`
+build string before proceeding.
+
+- `-c conda-forge` — cmor 3.15 and the science packages live on conda-forge.
+- `geocat-comp` is conda-only (used by the vertical/regrid code).
+
+### 2. Activate the environment
+
+```bash
+conda activate /projects/NS9560K/diagnostics/cmordev_env_312
+```
+
+### 3. Install the cmip7-prep project (editable)
+
+```bash
+cd /path/to/cmip7-prep
+pip install -e . --no-deps
+```
+
+`--no-deps` is intentional: the science packages are already installed by conda,
+and this stops pip from changing them.
+
+### 4. Install the pip-only packages
+
+```bash
+pip install gents dulwich cmip7-data-request-api
+```
+
+These three are not on conda-forge, so they must come from pip.
+
+## CMIP7 CMOR tables
+
+This recipe only provides the CMOR **library** (3.15). The matching **tables**
+live in the `cmip7-cmor-tables/` directory and must be the version that uses the
+CMIP7 controlled vocabulary (e.g. `CC-BY-4.0` license IDs and `gNNN` grid
+labels). Keep that checkout up to date, or CMOR will reject otherwise-valid runs.
+
+## Troubleshooting
+
+- **`gents` resolves from `~/.local/...` instead of the env:** a personal
+  user-folder copy is shadowing the env. Clear it, then reinstall into the env:
+  ```bash
+  pip uninstall gents      # removes the ~/.local copy
+  pip install gents        # reinstalls into the active env
+  ```
+- **`license_id "..." could not be found` / `grid_label "..." is invalid`:**
+  the `cmip7-cmor-tables` checkout is out of date. Update it to the version
+  matching CMOR 3.15 / the CMIP7 controlled vocabulary.

--- a/data/noresm_to_cmip7_aerosol.yaml
+++ b/data/noresm_to_cmip7_aerosol.yaml
@@ -1,0 +1,651 @@
+dataset_overrides:
+  institution_id: NCC
+  nominal_resolution: 200 km
+  source_id: NorESM3
+
+variables:
+
+  abs550aer_tavg-u-hxy-u:
+    description: Optical thickness of atmospheric aerosols at wavelength 550 nanometers.
+    dims: [lon, lat, time, lambda550nm]
+    formula: ABS550AL/DAYFOC
+    sources: [model_var: ABS550AL, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  abs550bc_tavg-u-hxy-u:
+    description: This is the black carbon aerosol optical depth at 550nm due to absorption
+    dims: [lon, lat, time, lambda550nm]
+    formula: A550_BC/DAYFOC
+    sources: [model_var: A550_BC, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  abs550dust_tavg-u-hxy-u:
+    description: This is the dust aerosol optical depth at 550nm due to absorption
+    dims: [lon, lat, time, lambda550nm]
+    formula: A550_DU/DAYFOC
+    sources: [model_var: A550_DU, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  abs550oa_tavg-u-hxy-u:
+    description: This is the particular organic matter aerosol optical depth at 550nm
+      due to absorption
+    dims: [lon, lat, time, lambda550nm]
+    formula: A550_POM/DAYFOC
+    sources: [model_var: A550_POM, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  abs550so4_tavg-u-hxy-u:
+    description: This is the sulphate aerosol optical depth at 550nm due to absorption
+    dims: [lon, lat, time, lambda550nm]
+    formula: A550_SO4/DAYFOC
+    sources: [model_var: A550_SO4, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  abs550ss_tavg-u-hxy-u:
+    description: This is the sea salt aerosol optical depth at 550nm due to absorption
+    dims: [lon, lat, time, lambda550nm]
+    formula: A550_SS/DAYFOC
+    sources: [model_var: A550_SS, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  airmass_tavg-al-hxy-u:
+    description: The mass of air in an atmospheric layer.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: AIRMASSL]
+    table: aerosol
+    units: kg m-2
+
+  ccn1_tavg-al-hxy-u:
+    description: This is the concentration of cloud condensation nuclei (CCN) at 1.0
+      percent supersaturation, based on aerosol chemical composition and size
+    dims: [lon, lat, lev, time, hur101pct]
+    formula: CCN7*1.e6
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: CCN7, model_var: e6]
+    table: aerosol
+    units: m-3
+
+  ccn_tavg-u-hxy-ccl:
+    description: 'proposed name: number_concentration_of_ambient_aerosol_in_air_at_liquid_water_cloud_top'
+    dims: [lon, lat, time]
+    formula: CCN_B/FCTL_B
+    sources: [model_var: CCN_B, model_var: FCTL_B]
+    table: aerosol
+    units: m-3
+
+  ccnp02_tavg-al-hxy-u:
+    description: This is the concentration of cloud condensation nuclei (CCN) at 0.2%
+      supersaturation, based on aerosol chemical composition and size
+    dims: [lon, lat, lev, time, hur100p2pct]
+    formula: CCN5*1.e6
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: CCN5, model_var: e6]
+    table: aerosol
+    units: m-3
+
+  cdnc_tavg-al-hxy-u:
+    description: Cloud Droplet Number Concentration in liquid water clouds.
+    dims: [lon, lat, lev, time]
+    formula: AWNC,AWNC/FREQL
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: AWNC, model_var: AWNC, model_var: FREQL]
+    table: aerosol
+    units: m-3
+
+  cheaqpso4_tavg-al-hxy-u:
+    description: 'proposed name: tendency_of_atmosphere_mass_content_of_sulfate_dry_aerosol_due_to_aqueous_phase_net_chemical_production'
+    dims: [lon, lat, lev, time]
+    formula: AQSO4_H2O2+AQSO4_O3
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: AQSO4_H2O2, model_var: AQSO4_O3]
+    table: aerosol
+    units: kg m-2 s-1
+
+  chegpso4_tavg-al-hxy-u:
+    description: 'proposed name: tendency_of_atmosphere_mass_content_of_sulfate_dry_aerosol_due_to_gas_phase_net_chemical_production'
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: GS_H2SO4]
+    table: aerosol
+    units: kg m-2 s-1
+
+  chepsoa_tavg-u-hxy-u:
+    description: If model lumps SOA emissions with POA, then the sum of POA and SOA
+      emissions is reported as OA emissions. "mass" refers to the mass of primary
+      organic matter, not mass of organic carbon alone.
+    dims: [lon, lat, time]
+    formula: GS_SOA_LV + GS_SOA_SV
+    sources: [model_var: GS_SOA_LV, model_var: GS_SOA_SV]
+    table: aerosol
+    units: kg m-2 s-1
+
+  cod_tavg-u-hxy-u:
+    description: The optical thickness is the integral along the path of radiation
+      of a volume scattering/absorption/attenuation coefficient. The radiative flux
+      is reduced by a factor exp(-optical_thickness) on traversing the path. A coordinate
+      variable of radiation_wavelength or radiation_frequency can be specified to
+      indicate that the optical thickness applies at specific wavelengths or frequencies.
+      The atmosphere optical thickness applies to radiation passing through the entire
+      atmosphere. "Cloud" means the component of extinction owing to the presence
+      of liquid or ice water particles. The specification of a physical process by
+      the phrase due_to_process means that the quantity named is a  single term in
+      a sum of terms which together compose the general quantity named by omitting
+      the phrase.
+    dims: [lon, lat, time]
+    formula: TAUTMODIS/CLTMODIS
+    sources: [model_var: TAUTMODIS, model_var: CLTMODIS]
+    table: aerosol
+    units: '1'
+
+  conccn_tavg-al-hxy-u:
+    description: This is the number concentration of air particles in air
+    dims: [lon, lat, lev, time]
+    formula: N_AER*1e6
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: N_AER, model_var: e6]
+    table: aerosol
+    units: m-3
+
+  do3chm_tavg-al-hxy-u:
+    description: Dry Deposition Rate of Dust
+    dims: [lon, lat, time]
+    sources: [model_var: dry_DUST]
+    table: aerosol
+    units: kg m-2 s-1
+
+  dryoa_tavg-u-hxy-u:
+    description: Dry Deposition Rate of Dry Aerosol Total Organic Matter
+    dims: [lon, lat, time]
+    sources: [model_var: dry_OM]
+    table: aerosol
+    units: kg m-2 s-1
+
+  dryso2_tavg-u-hxy-u:
+    description: Dry Deposition Rate of SO2
+    dims: [lon, lat, time]
+    sources: [model_var: DF_SO2]
+    table: aerosol
+    units: kg m-2 s-1
+
+  dryso4_tavg-u-hxy-u:
+    description: Dry Deposition Rate of SO4
+    dims: [lon, lat, time]
+    sources: [model_var: dry_SULFATE]
+    table: aerosol
+    units: kg m-2 s-1
+
+  dryss_tavg-u-hxy-u:
+    description: Dry Deposition Rate of Sea-Salt Aerosol
+    dims: [lon, lat, time]
+    sources: [model_var: dry_SALT]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emibc_tavg-u-hxy-u:
+    description: Integrate 3D emission field vertically to 2d field.
+    dims: [lon, lat, time]
+    sources: [model_var: emis_BC]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emibvoc_tavg-u-hxy-u:
+    description: Integrate 3D emission field vertically to 2d field._If_ fixed molecular
+      weight of NMVOC is not available in model, please provide in units of kilomole
+      m-2 s-1 (i.e. kg m-2 s-1 as if model NMVOC had molecular weight of 1) and add
+      a comment to your file.
+    dims: [lon, lat, time]
+    formula: emis_isoprene+emis_monoterp
+    sources: [model_var: emis_isoprene, model_var: emis_monoterp]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emidms_tavg-u-hxy-u:
+    description: Integrate 3D emission field vertically to 2d field.
+    dims: [lon, lat, time]
+    sources: [model_var: emis_DMS]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emidust_tavg-u-hxy-u:
+    description: Integrate 3D emission field vertically to 2d field.
+    dims: [lon, lat, time]
+    sources: [model_var: emis_DUST]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emiisop_tavg-u-hxy-u:
+    description: Integrate 3D emission field vertically to 2d field
+    dims: [lon, lat, time]
+    sources: [model_var: emis_isoprene]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emioa_tavg-u-hxy-u:
+    description: This is the sum of total emission of POA and total production of
+      SOA (emipoa+chepsoa). "Mass" refers to the mass of organic matter, not mass
+      of organic carbon alone. We recommend a scale factor of POM=1.4*OC, unless your
+      model has more detailed info available.  Integrate 3D chemical production and
+      emission field vertically to 2d field.
+    dims: [lon, lat, time]
+    sources: [model_var: emis_OM]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emiso2_tavg-u-hxy-u:
+    description: Integrate 3D emission field vertically to 2d field.
+    dims: [lon, lat, time]
+    sources: [model_var: emis_SO2]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emiso4_tavg-u-hxy-u:
+    description: Direct primary emission does not include secondary sulfate production.
+      Integrate 3D emission field vertically to 2d field.
+    dims: [lon, lat, time]
+    sources: [model_var: emis_SULFATE]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emiss_tavg-u-hxy-u:
+    description: Integrate 3D emission field vertically to 2d field.
+    dims: [lon, lat, time]
+    sources: [model_var: emis_SALT]
+    table: aerosol
+    units: kg m-2 s-1
+
+  emivoc_tavg-u-hxy-u:
+    description: Integrate 3D emission field vertically to 2d field. _If_ fixed molecular
+      weight of NMVOC is not available in model, please provide in units of kilomole
+      m-2 s-1 (i.e. kg m-2 s-1 as if model NMVOC had molecular weight of 1) and add
+      a comment to your file.
+    dims: [lon, lat, time]
+    formula: emis_isoprene+emis_monoterp
+    sources: [model_var: emis_isoprene, model_var: emis_monoterp]
+    table: aerosol
+    units: kg m-2 s-1
+
+  ho2_tavg-p39-hy-air:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.  The chemical formula of hydroperoxyl
+      radical is HO2.
+    dims: [time, plev, lat]
+    levels: {name: plev39, units: Pa}
+    sources: [model_var: HO2_aft]
+    table: aerosol
+    units: mol mol-1
+
+  isop_tavg-al-hxy-u:
+    description: Mole fraction of isoprene in air.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: isoprene]
+    table: aerosol
+    units: mol mol-1
+
+  lwp_tavg-u-hxy-u:
+    description: The total mass of liquid water in cloud per unit area.
+    dims: [lon, lat, time]
+    sources: [model_var: TGCLDLWP]
+    table: aerosol
+    units: kg m-2
+
+  mmraerh2o_tavg-al-hxy-u:
+    description: Mass fraction is used in the construction mass_fraction_of_X_in_Y,
+      where X is a material constituent of Y. It means the ratio of the mass of X
+      to the mass of Y (including X). "Aerosol" means the system of suspended liquid
+      or solid particles in air (except cloud droplets) and their carrier gas, the
+      air itself. "Ambient_aerosol" means that the aerosol is measured or modelled
+      at the ambient state of pressure, temperature and relative humidity that exists
+      in its immediate environment. "Ambient aerosol particles" are aerosol particles
+      that have taken up ambient water through hygroscopic growth. The extent of hygroscopic
+      growth depends on the relative humidity and the composition of the particles.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: MMR_AH2O]
+    table: aerosol
+    units: kg kg-1
+
+  mmrbc_tavg-al-hxy-u:
+    description: Dry mass fraction of black carbon aerosol particles in air.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: mmr_BC]
+    table: aerosol
+    units: kg kg-1
+
+  mmrdust_tavg-al-hxy-u:
+    description: Dry mass fraction of dust aerosol particles in air.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: mmr_DUST]
+    table: aerosol
+    units: kg kg-1
+
+  mmroa_tavg-al-hxy-u:
+    description: We recommend a scale factor of POM=1.4*OC, unless your model has
+      more detailed info available.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: mmr_OM]
+    table: aerosol
+    units: kg kg-1
+
+  mmrpm1_tavg-al-hxy-u:
+    description: Mass fraction atmospheric particulate compounds with an aerodynamic
+      diameter of less than or equal to 1 micrometers
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: MMRPM1]
+    table: aerosol
+    units: kg kg-1
+
+  mmrpm2p5_tavg-al-hxy-u:
+    description: Mass fraction atmospheric particulate compounds with an aerodynamic
+      diameter of less than or equal to 2.5 micrometers
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: MMRPM2P5]
+    table: aerosol
+    units: kg kg-1
+
+  mmrso4_tavg-al-hxy-u:
+    description: Dry mass of sulfate (SO4) in aerosol particles as a fraction of air
+      mass.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: mmr_SULFATE]
+    table: aerosol
+    units: kg kg-1
+
+  mmrsoa_tavg-al-hxy-u:
+    description: Mass fraction in the atmosphere of secondary organic aerosols (particulate
+      organic matter formed within the atmosphere from gaseous precursors; dry mass).
+    dims: [lon, lat, lev, time]
+    formula: SOA_NA+SOA_A1
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: SOA_NA, model_var: SOA_A1]
+    table: aerosol
+    units: kg kg-1
+
+  mmrss_tavg-al-hxy-u:
+    description: Mass fraction in the atmosphere of sea salt aerosol (dry mass).
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: mmr_SALT]
+    table: aerosol
+    units: kg kg-1
+
+  od443aer_tavg-u-hxy-u:
+    description: 'This is the aerosol optical depth (AOD) from the ambient aerosls
+      (i.e., includes aerosol water).  Does not include AOD from stratospheric aerosols
+      if these are prescribed but includes other possible background aerosol types.
+      Needs a comment attribute "wavelength: 443 nm"'
+    dims: [lon, lat, time, lambda443nm]
+    formula: DOD440/DAYFOC
+    sources: [model_var: DOD440, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  od550aer_tavg-u-hxy-u:
+    description: 'AOD from the ambient aerosls (i.e., includes aerosol water).  Does
+      not include AOD from stratospheric aerosols if these are prescribed but includes
+      other possible background aerosol types. Needs a comment attribute "wavelength:
+      550 nm"'
+    dims: [lon, lat, time, lambda550nm]
+    formula: DOD550/DAYFOC
+    sources: [model_var: DOD550, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  od550aerh2o_tavg-u-hxy-u:
+    description: 'proposed name: atmosphere_optical_thickness_due_to_water_ambient_aerosol'
+    dims: [lon, lat, time, lambda550nm]
+    formula: (DOD550-OD550DRY)/DAYFOC
+    sources: [model_var: DOD550, model_var: OD550DRY, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  od550bc_tavg-u-hxy-u:
+    description: Total aerosol AOD due to black carbon aerosol at a wavelength of
+      550 nanometres.
+    dims: [lon, lat, time, lambda550nm]
+    formula: D550_BC/DAYFOC
+    sources: [model_var: D550_BC, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  od550csaer_tavg-u-hxy-u:
+    description: 'AOD from the ambient aerosols in clear skies if od550aer is for
+      all-sky (i.e., includes aerosol water).  Does not include AOD from stratospheric
+      aerosols if these are prescribed but includes other possible background aerosol
+      types. Needs a comment attribute "wavelength: 550 nm"'
+    dims: [lon, lat, time, lambda550nm]
+    formula: CDOD550/DAYFOC/CLDFREE
+    sources: [model_var: CDOD550, model_var: DAYFOC, model_var: CLDFREE]
+    table: aerosol
+    units: '1'
+
+  od550dust_tavg-u-hxy-u:
+    description: Total aerosol AOD due to dust aerosol at a wavelength of 550 nanometres.
+    dims: [lon, lat, time, lambda550nm]
+    formula: D550_DU/DAYFOC
+    sources: [model_var: D550_DU, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  od550lt1aer_tavg-u-hxy-u:
+    description: od550 due to particles with wet diameter less than 1 um  ("ambient"
+      means "wetted"). When models do not include explicit size information, it can
+      be assumed that all anthropogenic aerosols and natural secondary aerosols have
+      diameter less than 1 um.
+    dims: [lon, lat, time, lambda550nm]
+    formula: (DLT_SS+DLT_DUST+DLT_SO4+DLT_BC+DLT_POM)/DAYFOC
+    sources: [model_var: DLT_SS, model_var: DLT_DUST, model_var: DLT_SO4, {
+        model_var: DLT_BC}, model_var: DLT_POM, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  od550oa_tavg-u-hxy-u:
+    description: total organic aerosol AOD, comprises all organic aerosols, primary
+      + secondary ; natural + anthropogenic including biomasss burning organic aerosol
+    dims: [lon, lat, time, lambda550nm]
+    formula: D550_POM/DAYFOC
+    sources: [model_var: D550_POM, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  od550so4_tavg-u-hxy-u:
+    description: Total aerosol AOD due to sulfate aerosol at a wavelength of 550 nanometres.
+    dims: [lon, lat, time, lambda550nm]
+    formula: D550_SO4/DAYFOC
+    sources: [model_var: D550_SO4, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  od550ss_tavg-u-hxy-u:
+    description: Total aerosol AOD due to sea salt aerosol at a wavelength of 550
+      nanometres.
+    dims: [lon, lat, time, lambda550nm]
+    formula: D550_SS/DAYFOC
+    sources: [model_var: D550_SS, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  od865aer_tavg-u-hxy-u:
+    description: 'AOD from the ambient aerosols (i.e., includes aerosol water).  Does
+      not include AOD from stratospheric aerosols if these are prescribed but includes
+      other possible background aerosol types. Needs a comment attribute "wavelength:
+      865 nm"'
+    dims: [lon, lat, time, lambda865nm]
+    formula: DOD870/DAYFOC
+    sources: [model_var: DOD870, model_var: DAYFOC]
+    table: aerosol
+    units: '1'
+
+  oh_tavg-al-hxy-u:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: OH_aft]
+    table: aerosol
+    units: mol mol-1
+
+  oh_tavg-p39-hy-air:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.
+    dims: [time, plev, lat]
+    levels: {name: plev39, units: Pa}
+    sources: [model_var: OH_aft]
+    table: aerosol
+    units: mol mol-1
+
+  reffclwtop_tavg-u-hxy-cl:
+    description: Droplets are liquid only.  This is the effective radius "as seen
+      from space" over liquid cloudy portion of grid cell. This is the value from
+      uppermost model layer with liquid cloud or, if available, or for some models
+      it is the sum over all liquid cloud tops, no matter where they occur, as long
+      as they are seen from the top of the atmosphere.TOA) each time sample when computing
+      monthly mean. Reported values are weighted by total liquid cloud top fraction
+      of  (as seen from TOA) each time sample when computing monthly mean.
+    dims: [lon, lat, time]
+    formula: REFFCLWMODIS/CLWMODIS
+    sources: [model_var: REFFCLWMODIS, model_var: CLWMODIS]
+    table: aerosol
+    units: m
+
+  rlutaf_tavg-u-hxy-u:
+    description: Flux corresponding to rlut resulting fom aerosol-free call to radiation
+    dims: [lon, lat, time]
+    sources: [model_var: FLNT_DRF]
+    table: aerosol
+    units: W m-2
+
+  rlutcsaf_tavg-u-hxy-u:
+    description: Flux corresponding to rlutcs resulting fom aerosol-free call to radiation
+    dims: [lon, lat, time]
+    sources: [model_var: FLNTCDRF]
+    table: aerosol
+    units: W m-2
+
+  rsutaf_tavg-u-hxy-u:
+    description: Flux corresponding to rsut resulting fom aerosol-free call to radiation
+    dims: [lon, lat, time]
+    sources: [model_var: FSNT_DRF]
+    table: aerosol
+    units: W m-2
+
+  rsutcsaf_tavg-u-hxy-u:
+    description: Flux corresponding to rsutcs resulting fom aerosol-free call to radiation
+    dims: [lon, lat, time]
+    sources: [model_var: FSNTCDRF]
+    table: aerosol
+    units: W m-2
+
+  so2_tavg-al-hxy-u:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: SO2]
+    table: aerosol
+    units: mol mol-1
+
+  tatp_tavg-u-hxy-u:
+    description: 2D monthly mean thermal tropopause calculated using WMO tropopause
+      definition on 3d temperature
+    dims: [lon, lat, time]
+    sources: [model_var: TROP_T]
+    table: aerosol
+    units: K
+
+  toz_tavg-u-hxy-u:
+    description: total ozone column in DU
+    dims: [lon, lat, time]
+    sources: [model_var: cb_ozone_c]
+    table: aerosol
+    units: m
+
+  ua_tavg-10hPa-hxy-air:
+    description: Zonal wind on the 10 hPa surface
+    dims: [lon, lat, time, p10]
+    sources: [model_var: U010]
+    table: aerosol
+    units: m s-1
+
+  wetbc_tavg-u-hxy-u:
+    description: Surface deposition rate of black carbon (dry mass) due to wet processes
+    dims: [lon, lat, time]
+    sources: [model_var: wet_BC]
+    table: aerosol
+    units: kg m-2 s-1
+
+  wetdust_tavg-u-hxy-u:
+    description: Surface deposition rate of dust (dry mass) due to wet processes
+    dims: [lon, lat, time]
+    sources: [model_var: wet_DUST]
+    table: aerosol
+    units: kg m-2 s-1
+
+  wetoa_tavg-u-hxy-u:
+    description: Deposition rate of organic matter in aerosols (measured by the dry
+      mass) due to wet processes
+    dims: [lon, lat, time]
+    sources: [model_var: wet_OM]
+    table: aerosol
+    units: kg m-2 s-1
+
+  wetso2_tavg-u-hxy-u:
+    description: Deposition rate of sulfur dioxide due to wet processes
+    dims: [lon, lat, time]
+    sources: [model_var: WD_A_SO2]
+    table: aerosol
+    units: kg m-2 s-1
+
+  wetso4_tavg-u-hxy-u:
+    description: 'proposed name: tendency_of_atmosphere_mass_content_of_sulfate_dry_aerosol_due_to_wet_deposition'
+    dims: [lon, lat, time]
+    sources: [model_var: wet_SULFATE]
+    table: aerosol
+    units: kg m-2 s-1
+
+  wetss_tavg-u-hxy-u:
+    description: Deposition rate of sea salt aerosols (measured by the dry mass) due
+      to wet processes
+    dims: [lon, lat, time]
+    sources: [model_var: wet_SALT]
+    table: aerosol
+    units: kg m-2 s-1
+
+  zg_tavg-10hPa-hxy-air:
+    description: Geopotential height on the 10 hPa surface
+    dims: [lon, lat, time, p10]
+    sources: [model_var: Z010]
+    table: aerosol
+    units: m

--- a/data/noresm_to_cmip7_atmosChem.yaml
+++ b/data/noresm_to_cmip7_atmosChem.yaml
@@ -1,0 +1,85 @@
+dataset_overrides:
+  institution_id: NCC
+  nominal_resolution: 200 km
+  source_id: NorESM3
+
+variables:
+
+  cfc11_tavg-u-hm-u:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.  The chemical formula of CFC11 is CFCl3.  The
+      IUPAC name for CFC11 is trichloro-fluoro-methane.
+    dims: [time]
+    sources: [model_var: f11vmr]
+    table: atmosChem
+    units: '1.00E-12'
+
+  cfc12_tavg-u-hm-u:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.  The chemical formula of CFC12 is CF2Cl2.  The
+      IUPAC name for CFC12 is dichloro-difluoro-methane.
+    dims: [time]
+    sources: [model_var: f12vmr]
+    table: atmosChem
+    units: '1.00E-12'
+
+  ch4_tavg-p39-hy-air:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.
+    dims: [time, plev, lat]
+    levels: {name: plev39, units: Pa}
+    sources: [model_var: CH4]
+    table: atmosChem
+    units: mol mol-1
+
+  ch4_tavg-u-hm-u:
+    description: Global Mean Mole Fraction of CH4
+    dims: [time]
+    sources: [model_var: ch4vmr]
+    table: atmosChem
+    units: '1.00E-09'
+
+  dms_tavg-al-hxy-u:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: DMS]
+    table: atmosChem
+    units: mol mol-1
+
+  n2o_tavg-u-hm-u:
+    description: Global mean Nitrous Oxide (N2O)
+    dims: [time]
+    sources: [model_var: n2ovmr]
+    table: atmosChem
+    units: '1.00E-09'
+
+  o3_tavg-al-hxy-u:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.
+    dims: [lon, lat, lev, time]
+    levels: {name: standard_hybrid_sigma, src_axis_bnds: ilev, src_axis_name: lev,
+      units: '1'}
+    sources: [model_var: ozone]
+    table: atmosChem
+    units: mol mol-1
+
+  o3_tavg-p19-hxy-air:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.
+    dims: [time, plev, lat, lon]
+    levels: {name: plev19, units: Pa}
+    sources: [model_var: ozone]
+    table: atmosChem
+    units: mol mol-1
+
+  o3_tavg-p39-hy-air:
+    description: Mole fraction is used in the construction mole_fraction_of_X_in_Y,
+      where X is a material constituent of Y.
+    dims: [time, plev, lat]
+    levels: {name: plev39, units: Pa}
+    sources: [model_var: ozone]
+    table: atmosChem
+    units: mol mol-1

--- a/data/noresm_to_cmip7_land.yaml
+++ b/data/noresm_to_cmip7_land.yaml
@@ -51,7 +51,8 @@ variables:
   cLeaf_tavg-u-hxy-lnd:
     description: Carbon mass per unit area in leaves.
     dims: [lon, lat, time]
-    sources: [model_var: FATES_LEAFC]
+    formula: (FATES_LEAFC)*FATES_FRACTION
+    sources: [model_var: FATES_LEAFC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
 
@@ -60,7 +61,8 @@ variables:
       dead organic matter composed of coarse wood. It is distinct from fine litter.
       The precise distinction between "fine" and "coarse" is model dependent.'
     dims: [lon, lat, time]
-    sources: [model_var: FATES_LITTER_BG_CWD_EL]
+    formula: (FATES_LITTER_BG_CWD_EL)*FATES_FRACTION
+    sources: [model_var: FATES_LITTER_BG_CWD_EL, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
 
@@ -77,14 +79,16 @@ variables:
     description: Surface or near-surface litter pool fed by leaf and above-ground
       litterfall
     dims: [lon, lat, time]
-    sources: [model_var: FATES_LITTER_AG_FINE_EL]
+    formula: (FATES_LITTER_AG_FINE_EL)*FATES_FRACTION
+    sources: [model_var: FATES_LITTER_AG_FINE_EL, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
 
   cOther_tavg-u-hxy-lnd:
     description: E.g. fruits, seeds, etc.
     dims: [lon, lat, time]
-    sources: [model_var: FATES_SEED_BANK]
+    formula: (FATES_SEED_BANK)*FATES_FRACTION
+    sources: [model_var: FATES_SEED_BANK, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
 
@@ -133,7 +137,8 @@ variables:
   cStem_tavg-u-hxy-lnd:
     description: including sapwood and hardwood.
     dims: [lon, lat, time]
-    sources: [model_var: FATES_STRUCTC]
+    formula: (FATES_STRUCTC)*FATES_FRACTION
+    sources: [model_var: FATES_STRUCTC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2
 
@@ -178,7 +183,8 @@ variables:
   cnc_tavg-u-hxy-u:
     description: Canopy covered fraction
     dims: [lon, lat, time]
-    sources: [model_var: FATES_AREA_PLANTS]
+    formula: (FATES_AREA_PLANTS)*FATES_FRACTION
+    sources: [model_var: FATES_AREA_PLANTS, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
@@ -269,14 +275,16 @@ variables:
     description: From all sources,  Including natural, anthropogenic and Land-use
       change. Only total fire emissions can be compared to observations.
     dims: [lon, lat, time]
-    sources: [model_var: FATES_FIRE_CLOSS]
+    formula: (FATES_FIRE_CLOSS)*FATES_FRACTION
+    sources: [model_var: FATES_FIRE_CLOSS, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
   fFireNat_tavg-u-hxy-lnd:
     description: CO2 emissions from natural fires
     dims: [lon, lat, time]
-    sources: [model_var: FATES_FIRE_CLOSS]
+    formula: (FATES_FIRE_CLOSS)*FATES_FRACTION
+    sources: [model_var: FATES_FIRE_CLOSS, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -286,8 +294,9 @@ variables:
       any CO2 flux from fire included in fLuc, defined below (CO2 Flux to Atmosphere
       from Land Use Change).
     dims: [lon, lat, time]
+    formula: (FATES_FIRE_CLOSS)*FATES_FRACTION
     positive: up
-    sources: [model_var: FATES_FIRE_CLOSS]
+    sources: [model_var: FATES_FIRE_CLOSS, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -295,7 +304,8 @@ variables:
     description: Carbon mass flux per unit area into soil from litter (dead plant
       material in or above the soil).
     dims: [lon, lat, time]
-    sources: [model_var: FATES_LITTER_OUT_EL]
+    formula: (FATES_LITTER_OUT_EL)*FATES_FRACTION
+    sources: [model_var: FATES_LITTER_OUT_EL, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -322,6 +332,7 @@ variables:
       soil), soil.
     dims: [lon, lat, time]
     formula: F_N2O_DENIT+F_N2O_NIT
+    positive: up
     sources: [model_var: F_N2O_DENIT, model_var: F_N2O_NIT]
     table: land
     units: kg m-2 s-1
@@ -444,7 +455,8 @@ variables:
     description: Required for unambiguous separation of vegetation and soil + litter
       turnover times, since total fire flux draws from both sources
     dims: [lon, lat, time]
-    sources: [model_var: FATES_FIRE_CLOSS]
+    formula: (FATES_FIRE_CLOSS)*FATES_FRACTION
+    sources: [model_var: FATES_FIRE_CLOSS, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -477,7 +489,8 @@ variables:
       standard names mass_flux_of_carbon_into_litter_from_vegetation_due_to_mortality
       and mass_flux_of_carbon_into_litter_from_vegetation_due_to_senescence is mass_flux_of_carbon_into_litter_from_vegetation.
     dims: [lon, lat, time]
-    sources: [model_var: FATES_LITTER_IN_EL]
+    formula: (FATES_LITTER_IN_EL)*FATES_FRACTION
+    sources: [model_var: FATES_LITTER_IN_EL, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -494,14 +507,16 @@ variables:
     description: Cumulative percentage transitions over the year; note that percentage
       should be reported as a percentage of atmospheric grid cell
     dims: [lon, lat, landuse, time]
-    sources: [model_var: FATES_TRANSITION_MATRIX_LULU]
+    formula: (FATES_TRANSITION_MATRIX_LULU)*FATES_FRACTION
+    sources: [model_var: FATES_TRANSITION_MATRIX_LULU, model_var: FATES_FRACTION]
     table: land
     units: '%'
   fracOutLut_tsum-u-hxy-lnd:
     description: Cumulative percentage transitions over the year; note that percentage
       should be reported as percentage of atmospheric grid cell
     dims: [lon, lat, landuse, time]
-    sources: [model_var: FATES_TRANSITION_MATRIX_LULU]
+    formula: (FATES_TRANSITION_MATRIX_LULU)*FATES_FRACTION
+    sources: [model_var: FATES_TRANSITION_MATRIX_LULU, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
@@ -512,7 +527,8 @@ variables:
       this biomass and the difference is referred to as the net primary production.
       Reported on land-use tiles.
     dims: [lon, lat, landuse, time]
-    sources: [model_var: FATES_GPP_LU]
+    formula: (FATES_GPP_LU)*FATES_FRACTION
+    sources: [model_var: FATES_GPP_LU, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -522,7 +538,8 @@ variables:
       photosynthesis in plants or phytoplankton. The producers also respire some of
       this biomass and the difference is referred to as the net primary production.
     dims: [lon, lat, time]
-    sources: [model_var: FATES_GPP]
+    formula: (FATES_GPP)*FATES_FRACTION
+    sources: [model_var: FATES_GPP, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -553,7 +570,7 @@ variables:
   grassFracC3_tavg-u-hxy-u:
     description: Percentage of entire grid cell covered by C3 natural grass.
     dims: [lon, lat, time, typec3natg]
-    formula: (sumoverpft(FATES_CROWNAREA_PF, pftlist=[12, 13], dimname='fates_levpft'))*FATES_FRACTION
+    formula: (FATES_CROWNAREA_PF(12+13))*FATES_FRACTION
     sources: [model_var: FATES_CROWNAREA_PF, model_var: FATES_FRACTION]
     table: land
     units: '%'
@@ -586,7 +603,8 @@ variables:
     description: A ratio obtained by dividing the total upper leaf surface area of
       vegetation by the (horizontal) surface area of the land on which it grows.
     dims: [lon, lat, time]
-    sources: [model_var: FATES_LAI]
+    formula: (FATES_LAI)*FATES_FRACTION
+    sources: [model_var: FATES_LAI, model_var: FATES_FRACTION]
     table: land
     units: '1'
 
@@ -738,7 +756,8 @@ variables:
   nppLeaf_tavg-u-hxy-lnd:
     description: This is the rate of carbon uptake by leaves due to NPP
     dims: [lon, lat, time]
-    sources: [model_var: FATES_LEAF_ALLOC]
+    formula: (FATES_LEAF_ALLOC)*FATES_FRACTION
+    sources: [model_var: FATES_LEAF_ALLOC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -754,7 +773,8 @@ variables:
       solely with respect to the B contained in A, neglecting all other chemical constituents
       of A.'
     dims: [lon, lat, landuse, time]
-    sources: [model_var: FATES_NPP_LU]
+    formula: (FATES_NPP_LU)*FATES_FRACTION
+    sources: [model_var: FATES_NPP_LU, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -777,7 +797,8 @@ variables:
   nppStem_tavg-u-hxy-lnd:
     description: added for completeness with npp_root
     dims: [lon, lat, time]
-    sources: [model_var: FATES_STEM_ALLOC]
+    formula: (FATES_STEM_ALLOC)*FATES_FRACTION
+    sources: [model_var: FATES_STEM_ALLOC, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -793,8 +814,9 @@ variables:
       solely with respect to the B contained in A, neglecting all other chemical constituents
       of A.'
     dims: [lon, lat, time]
+    formula: (FATES_NPP)*FATES_FRACTION
     positive: up
-    sources: [model_var: FATES_NPP]
+    sources: [model_var: FATES_NPP, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -868,7 +890,8 @@ variables:
   raLeaf_tavg-u-hxy-lnd:
     description: added for completeness with Ra_root
     dims: [lon, lat, time]
-    sources: [model_var: FATES_LEAFMAINTAR]
+    formula: (FATES_LEAFMAINTAR)*FATES_FRACTION
+    sources: [model_var: FATES_LEAFMAINTAR, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -895,7 +918,8 @@ variables:
   raStem_tavg-u-hxy-lnd:
     description: added for completeness with Ra_root
     dims: [lon, lat, time]
-    sources: [model_var: FATES_LSTEMMAINTAR]
+    formula: (FATES_LSTEMMAINTAR)*FATES_FRACTION
+    sources: [model_var: FATES_LSTEMMAINTAR, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -904,7 +928,8 @@ variables:
       respiration on land (respiration by producers) [see rh for heterotrophic production].
       Calculated on vegetation type.
     dims: [lon, lat, vegtype, time]
-    sources: [model_var: FATES_AUTORESP]
+    formula: (FATES_AUTORESP)*FATES_FRACTION
+    sources: [model_var: FATES_AUTORESP, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -913,6 +938,7 @@ variables:
       respiration on land (respiration by producers) [see rh for heterotrophic production]
     dims: [lon, lat, time]
     formula: FATES_AUTORESP*FATES_FRACTIONTION
+    positive: up
     sources: [model_var: FATES_AUTORESP, model_var: FATES_FRACTIONTION]
     table: land
     units: kg m-2 s-1
@@ -974,7 +1000,8 @@ variables:
     description: Carbon mass flux per unit area into atmosphere due to heterotrophic
       respiration on land (respiration by consumers), calculated on vegetation type.
     dims: [lon, lat, vegtype, time]
-    sources: [model_var: FATES_HET_RESP]
+    formula: (FATES_HET_RESP)*FATES_FRACTION
+    sources: [model_var: FATES_HET_RESP, model_var: FATES_FRACTION]
     table: land
     units: kg m-2 s-1
 
@@ -1176,14 +1203,16 @@ variables:
     description: Percentage of grid cell that is covered by vegetation.This SHOULD
       be the sum of tree, grass (natural and pasture), crop and shrub fractions.
     dims: [lon, lat, time, typeveg]
-    sources: [model_var: FATES_AREA_PLANTS]
+    formula: (FATES_AREA_PLANTS)*FATES_FRACTION
+    sources: [model_var: FATES_AREA_PLANTS, model_var: FATES_FRACTION]
     table: land
     units: '%'
 
   vegHeight_tavg-u-hxy-ng:
     description: Vegetation height averaged over the grass fraction of a grid cell.
     dims: [lon, lat, time]
-    sources: [model_var: FATES_CA_WEIGHTED_HEIGHT]
+    formula: (FATES_CA_WEIGHTED_HEIGHT)*FATES_FRACTION
+    sources: [model_var: FATES_CA_WEIGHTED_HEIGHT, model_var: FATES_FRACTION]
     table: land
     units: m
 
@@ -1191,7 +1220,8 @@ variables:
     description: Vegetation height averaged over all vegetation types and over the
       vegetated fraction of a grid cell.
     dims: [lon, lat, time]
-    sources: [model_var: FATES_CA_WEIGHTED_HEIGHT]
+    formula: (FATES_CA_WEIGHTED_HEIGHT)*FATES_FRACTION
+    sources: [model_var: FATES_CA_WEIGHTED_HEIGHT, model_var: FATES_FRACTION]
     table: land
     units: m
 

--- a/data/noresm_to_cmip7_seaice.yaml
+++ b/data/noresm_to_cmip7_seaice.yaml
@@ -4,14 +4,12 @@ variables:
 
   siage_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siage_d}, {freq: mon, model_var: siage}]
     table: seaIce
     units: yr
 
   sialgc_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sialgc_d}, {freq: mon, model_var: sialgc}]
     table: seaIce
     units: kg m-2
@@ -30,35 +28,30 @@ variables:
 
   sichl_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sichl_d}, {freq: mon, model_var: sichl}]
     table: seaIce
     units: kg m-2
 
   sicompstren_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sicompstren_d}, {freq: mon, model_var: sicompstren}]
     table: seaIce
     units: N m-1
 
   siconc_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siconc_d}, {freq: mon, model_var: siconc}]
     table: seaIce
     units: '%'
 
   siconc_tavg-u-hxy-u:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siconc_d}, {freq: mon, model_var: siconc}]
     table: seaIce
     units: '%'
 
   siconca_tavg-u-hxy-u:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siconca_d}, {freq: mon, model_var: siconca}]
     table: seaIce
     units: '%'
@@ -66,7 +59,6 @@ variables:
   sidconcdyn_tavg-u-hxy-sea:
     dims: [time, nj, ni]
     long_name: Dynamic Sea Ice Concentration Change
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidconcdyn_d}, {freq: mon, model_var: sidconcdyn}]
     table: seaIce
     units: s-1
@@ -74,126 +66,108 @@ variables:
   sidconcth_tavg-u-hxy-sea:
     dims: [time, nj, ni]
     long_name: Sea Ice Concentration Change due to Thickness Changes
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidconcth_d}, {freq: mon, model_var: sidconcth}]
     table: seaIce
     units: s-1
 
   sidconcth_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidconcth_d}, {freq: mon, model_var: sidconcth}]
     table: seaIce
     units: kg m-2
 
   sidivvel_tpt-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidivvel_d}, {freq: mon, model_var: sidivvel}]
     table: seaIce
     units: s-1
 
   sidmassdyn_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmassdyn_d}, {freq: mon, model_var: sidmassdyn}]
     table: seaIce
     units: kg m-2 s-1
 
   sidmassgrowthbot_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmassgrowthbot_d}, {freq: mon, model_var: sidmassgrowthbot}]
     table: seaIce
     units: kg m-2 s-1
 
   sidmassgrowthsi_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmassgrowthsi_d}, {freq: mon, model_var: sidmassgrowthsi}]
     table: seaIce
     units: kg m-2 s-1
 
   sidmassgrowthwat_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmassgrowthwat_d}, {freq: mon, model_var: sidmassgrowthwat}]
     table: seaIce
     units: kg m-2 s-1
 
   sidmassmeltbot_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmassmeltbot_d}, {freq: mon, model_var: sidmassmeltbot}]
     table: seaIce
     units: kg m-2 s-1
 
   sidmassmeltlat_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmassmeltlat_d}, {freq: mon, model_var: sidmassmeltlat}]
     table: seaIce
     units: kg m-2 s-1
 
   sidmassmelttop_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmassmelttop_d}, {freq: mon, model_var: sidmassmelttop}]
     table: seaIce
     units: kg m-2 s-1
 
   sidmassth_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmassth_d}, {freq: mon, model_var: sidmassth}]
     table: seaIce
     units: kg m-2 s-1
 
   sidmasstranx_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmasstranx_d}, {freq: mon, model_var: sidmasstranx}]
     table: seaIce
     units: kg s-1
 
   sidmasstranx_tavg-u-hxy-u:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmasstranx_d}, {freq: mon, model_var: sidmasstranx}]
     table: seaIce
     units: kg s-1
 
   sidmasstrany_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmasstrany_d}, {freq: mon, model_var: sidmasstrany}]
     table: seaIce
     units: kg s-1
 
   sidmasstrany_tavg-u-hxy-u:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidmasstrany_d}, {freq: mon, model_var: sidmasstrany}]
     table: seaIce
     units: kg s-1
 
   sidragbot_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidragbot_d}, {freq: mon, model_var: sidragbot}]
     table: seaIce
     units: '1'
 
   sidragtop_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sidragtop_d}, {freq: mon, model_var: sidragtop}]
     table: seaIce
     units: '1'
 
   sieqthick_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sieqthick_d}, {freq: mon, model_var: sieqthick}]
     table: seaIce
     units: m
@@ -212,7 +186,6 @@ variables:
 
   sifb_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sifb_d}, {freq: mon, model_var: sifb}]
     table: seaIce
     units: m
@@ -220,7 +193,6 @@ variables:
   siflcondbot_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: siflcondbot_d}, {freq: mon, model_var: siflcondbot}]
     table: seaIce
     units: W m-2
@@ -228,21 +200,18 @@ variables:
   siflcondtop_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: siflcondtop_d}, {freq: mon, model_var: siflcondtop}]
     table: seaIce
     units: W m-2
 
   siflfwbot_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siflfwbot_d}, {freq: mon, model_var: siflfwbot}]
     table: seaIce
     units: kg m-2 s-1
 
   siflfwdrain_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siflfwdrain_d}, {freq: mon, model_var: siflfwdrain}]
     table: seaIce
     units: kg m-2 s-1
@@ -250,7 +219,6 @@ variables:
   sifllattop_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: sifllattop_d}, {freq: mon, model_var: sifllattop}]
     table: seaIce
     units: W m-2
@@ -258,7 +226,6 @@ variables:
   siflsensbot_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: siflsensbot_d}, {freq: mon, model_var: siflsensbot}]
     table: seaIce
     units: W m-2
@@ -266,112 +233,96 @@ variables:
   siflsenstop_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: siflsenstop_d}, {freq: mon, model_var: siflsenstop}]
     table: seaIce
     units: W m-2
 
   siflswdbot_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siflswdbot_d}, {freq: mon, model_var: siflswdbot}]
     table: seaIce
     units: W m-2
 
   siflswdtop_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siflswdtop_d}, {freq: mon, model_var: siflswdtop}]
     table: seaIce
     units: W m-2
 
   siflswutop_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siflswutop_d}, {freq: mon, model_var: siflswutop}]
     table: seaIce
     units: m
 
   siforcecoriolx_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siforcecoriolx_d}, {freq: mon, model_var: siforcecoriolx}]
     table: seaIce
     units: N m-2
 
   siforcecorioly_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siforcecorioly_d}, {freq: mon, model_var: siforcecorioly}]
     table: seaIce
     units: N m-2
 
   siforceintstrx_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siforceintstrx_d}, {freq: mon, model_var: siforceintstrx}]
     table: seaIce
     units: N m-2
 
   siforceintstry_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siforceintstry_d}, {freq: mon, model_var: siforceintstry}]
     table: seaIce
     units: N m-2
 
   siforcetiltx_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siforcetiltx_d}, {freq: mon, model_var: siforcetiltx}]
     table: seaIce
     units: N m-2
 
   siforcetilty_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siforcetilty_d}, {freq: mon, model_var: siforcetilty}]
     table: seaIce
     units: N m-2
 
   sigpp_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sigpp_d}, {freq: mon, model_var: sigpp}]
     table: seaIce
     units: m s-1
 
   siitdconc_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sitdconc_d}, {freq: mon, model_var: sitdconc}]
     table: seaIce
     units: kg m-2
 
   siitdsnconc_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sitdsnconc_d}, {freq: mon, model_var: sitdsnconc}]
     table: seaIce
     units: kg m-2
 
   siitdsnthick_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siitdsnthick_d}, {freq: mon, model_var: siitdsnthick}]
     table: seaIce
     units: m
 
   siitdthick_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siitdthick_d}, {freq: mon, model_var: siitdthick}]
     table: seaIce
     units: m
 
   simass_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: simass_d}, {freq: mon, model_var: simass}]
     table: seaIce
     units: kg m-2
@@ -379,147 +330,126 @@ variables:
   simassacrossline_tavg-u-ht-u:
     dims: [time, latitude]
     long_name: Sea Ice Mass Across Line
-    regrid_method: conservative
     sources: [{freq: day, model_var: simassacrossline_d}, {freq: mon, model_var: simassacrossline}]
     table: seaIce
     units: kg m-2
 
   simpconc_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: simpconc_d}, {freq: mon, model_var: simpconc}]
     table: seaIce
     units: '%'
 
   simpeffconc_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: simpeffconc_d}, {freq: mon, model_var: simpeffconc}]
     table: seaIce
     units: '%'
 
   simprefrozen_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: simprefrozen_d}, {freq: mon, model_var: simprefrozen}]
     table: seaIce
     units: m
 
   simprefrozen_tavg-u-hxy-simp:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: simprefrozen_d}, {freq: mon, model_var: simprefrozen}]
     table: seaIce
     units: m
 
   simpthick_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: simpthick_d}, {freq: mon, model_var: simpthick}]
     table: seaIce
     units: m
 
   simpthick_tavg-u-hxy-simp:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: simpthick_d}, {freq: mon, model_var: simpthick}]
     table: seaIce
     units: m
 
   sino3_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sino3_d}, {freq: mon, model_var: sino3}]
     table: seaIce
     units: kg m-2
 
   sipr_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sipr_d}, {freq: mon, model_var: sipr}]
     table: seaIce
     units: kg m-2 s-1
 
   sirdgconc_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sirdgconc_d}, {freq: mon, model_var: sirdgconc}]
     table: seaIce
     units: '%'
 
   sirdgthick_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sirdgthick_d}, {freq: mon, model_var: sirdgthick}]
     table: seaIce
     units: m
 
   sisali_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisali_d}, {freq: mon, model_var: sisali}]
     table: seaIce
     units: 100E-03
 
   sisaltmass_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisaltmass_d}, {freq: mon, model_var: sisaltmass}]
     table: seaIce
     units: kg m-2
 
   sishearvel_tpt-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sishearvel_d}, {freq: mon, model_var: sishearvel}]
     table: seaIce
     units: m s-1
 
   sisi_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisi_d}, {freq: mon, model_var: sisi}]
     table: seaIce
     units: kg m-2 s-1
 
   sisndmassdyn_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisndmassdyn_d}, {freq: mon, model_var: sisndmassdyn}]
     table: seaIce
     units: kg m-2 s-1
 
   sisndmassmelt_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisndmassmelt_d}, {freq: mon, model_var: sisndmassmelt}]
     table: seaIce
     units: kg m-2 s-1
 
   sisndmasssi_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisndmasssi_d}, {freq: mon, model_var: sisndmasssi}]
     table: seaIce
     units: kg m-2 s-1
 
   sisndmasssnf_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisndmasssnf_d}, {freq: mon, model_var: sisndmasssnf}]
     table: seaIce
     units: kg m-2 s-1
 
   sisndmasssubl_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisndmasssubl_d}, {freq: mon, model_var: sisndmasssubl}]
     table: seaIce
     units: kg m-2 s-1
 
   sisndmasswind_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisndmasswind_d}, {freq: mon, model_var: sisndmasswind}]
     table: seaIce
     units: kg m-2 s-1
@@ -527,7 +457,6 @@ variables:
   sisnhc_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisnhc_d}, {freq: mon, model_var: sisnhc}]
     table: seaIce
     units: J m-2
@@ -546,35 +475,30 @@ variables:
   sisnmassacrossline_tavg-u-ht-u:
     dims: [time, latitude]
     long_name: Sea Ice Mass Across Line
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisnmassacrossline_d}, {freq: mon, model_var: sisnmassacrossline}]
     table: seaIce
     units: kg m-2 s-1
 
   sisnthick_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sisnthick_d}, {freq: mon, model_var: sisnthick}]
     table: seaIce
     units: m
 
   sispeed_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sispeed_d}, {freq: mon, model_var: sispeed}]
     table: seaIce
     units: m s-1
 
   sistressave_tpt-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sistressave_d}, {freq: mon, model_var: sistressave}]
     table: seaIce
     units: N m-2
 
   sistressmax_tpt-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sistressmax_d}, {freq: mon, model_var: sistressmax}]
     table: seaIce
     units: N m-2
@@ -582,7 +506,6 @@ variables:
   sistrxdtop_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: sistrxdtop_d}, {freq: mon, model_var: sistrxdtop}]
     table: seaIce
     units: N m-2
@@ -590,7 +513,6 @@ variables:
   sistrxubot_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: sistrxubot_d}, {freq: mon, model_var: sistrxubot}]
     table: seaIce
     units: N m-2
@@ -598,7 +520,6 @@ variables:
   sistrydtop_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: sistrydtop_d}, {freq: mon, model_var: sistrydtop}]
     table: seaIce
     units: N m-2
@@ -606,70 +527,60 @@ variables:
   sistryubot_tavg-u-hxy-si:
     dims: [time, nj, ni]
     positive: down
-    regrid_method: conservative
     sources: [{freq: day, model_var: sistryubot_d}, {freq: mon, model_var: sistryubot}]
     table: seaIce
     units: N m-2
 
   sitempbot_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sitempbot_d}, {freq: mon, model_var: sitempbot}]
     table: seaIce
     units: K
 
   sitempsnic_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sitempsnic_d}, {freq: mon, model_var: sitempsnic}]
     table: seaIce
     units: K
 
   sitemptop_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sitemptop_d}, {freq: mon, model_var: sitemptop}]
     table: seaIce
     units: K
 
   sithick_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sithick_d}, {freq: mon, model_var: sithick}]
     table: seaIce
     units: m
 
   sithick_tavg-u-hxy-sir:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sithick_d}, {freq: mon, model_var: sithick}]
     table: seaIce
     units: m
 
   sitimefrac_tavg-u-hxy-sea:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sitimefrac_d}, {freq: mon, model_var: sitimefrac}]
     table: seaIce
     units: '1'
 
   siu_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siu_d}, {freq: mon, model_var: siu}]
     table: seaIce
     units: m s-1
 
   siv_tavg-u-hxy-ifs:
     dims: [time, latitude, longitude]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siv_d}, {freq: mon, model_var: siv}]
     table: seaIce
     units: m s-1
 
   siv_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: siv_d}, {freq: mon, model_var: siv}]
     table: seaIce
     units: m s-1
@@ -687,7 +598,6 @@ variables:
 
   sivol_tavg-u-hxy-si:
     dims: [time, nj, ni]
-    regrid_method: conservative
     sources: [{freq: day, model_var: sivol_d}, {freq: mon, model_var: sivol}]
     table: seaIce
     units: m3 m-3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,13 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.10.13,<3.14"
 
-# Dependency management is now handled by your conda environment.
-# Example setup:
-#   conda create -n cmip7-prep python=3.13 xarray numpy dask xesmf cmor cftime pyyaml click pandas tqdm
+# Dependency management is handled by your conda environment.
+# Example setup (Python 3.12 is required for conda cmor 3.15):
+#   conda create -n cmip7-prep -c conda-forge python=3.12 cmor=3.15 xarray numpy \
+#     dask xesmf cftime pyyaml click pandas tqdm geocat-comp
 #   conda activate cmip7-prep
-#   pip install dulwich
+#   pip install -e . --no-deps
+#   pip install gents dulwich cmip7-data-request-api
 # Optional performance
 dask = {extras = ["array", "distributed"], version = "^2024.7.0", optional = true}
 zarr = {version = "^2.18.2", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,9 @@
 name = "cmip7-prep"
 version = "0.2.0"
 description = "Prepare CESM outputs for CMIP7 using CMOR, with SE->1deg regridding."
-authors = ["Jim Edwards <jedwards@example.com>"]
+authors = ["Jim Edwards <jedwards@example.com>",
+	"Mariana Vertenstein <mvertens@example.com>",
+	"Marit Sandstad <maritsandstad@example.com>"]
 readme = "README.md"
 packages = [{ include = "cmip7_prep", from = "src" }]
 # Include non-Python data files in both sdist and wheel
@@ -35,6 +37,9 @@ pre-commit = "4.3.0"
 
 [tool.poetry.scripts]
 cmip7-prep = "cmip7_prep.cli:app"
+
+[tool.pylint.messages_control]
+disable = ["fixme"]
 
 [build-system]
 requires = ["poetry-core>=1.8.0"]

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -65,8 +65,9 @@ _DATE_RE = re.compile(
 )
 
 # Path for cmor tables
-TABLES_cesm = "/glade/derecho/scratch/jedwards/cmip7-prep/cmip7-cmor-tables/"
-TABLES_noresm = "/nird/datalake/NS9560K/mvertens/packages/cmip7-prep/cmip7-cmor-tables/"
+# TODO: the following TABLES_cesm is no longer valid - can the TABLES_noresm be used?
+#TABLES_cesm = "/glade/derecho/scratch/jedwards/cmip7-prep/cmip7-cmor-tables/"
+TABLES_noresm = str(Path(__file__).parent.parent / "cmip7-cmor-tables")
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -410,7 +410,10 @@ def process_one_var(
                 results.append(
                     (str(varname), "analyzed native mom6 grid (realize applied)")
                 )
-            elif realm == "seaIce" and len(dims) == 1:
+            elif realm == "seaIce" and (model == "noresm" or len(dims) == 1):
+                # NorESM seaIce is always kept on the native CICE (nj, ni) grid:
+                # no regridding, regardless of dims. CESM seaIce keeps the prior
+                # behavior (native only for scalar/integrated len(dims) == 1 vars).
                 logger.info(
                     f"Preparing seaIce field variants via realize_all for {varname}"
                 )

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -425,6 +425,15 @@ def process_one_var(
                     )
                     if "time_bounds" in ds_native and "time_bounds" not in ds_v:
                         ds_v = ds_v.assign(time_bounds=ds_native["time_bounds"])
+                    # Carry the native CICE grid definition (cell centers + vertex
+                    # bounds) into the trimmed variant dataset, but only for 2D
+                    # (nj, ni) variants that are written on the native grid. TLAT/TLON
+                    # ride along as coords, but the *_bounds vars are data_vars and
+                    # would be dropped by the realize_all projection.
+                    if "nj" in da.dims and "ni" in da.dims:
+                        for gname in ("TLAT", "TLON", "latt_bounds", "lont_bounds"):
+                            if gname in ds_native and gname not in ds_v:
+                                ds_v = ds_v.assign({gname: ds_native[gname]})
                     cmor_items.append((ds_v, variant_cfg))
                 results.append(
                     (

--- a/scripts/cmor_driver.py
+++ b/scripts/cmor_driver.py
@@ -73,6 +73,8 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 REALM_YAML_MAP = {
     "noresm": {
         "atmos": "noresm_to_cmip7_atmos.yaml",
+        "atmosChem": "noresm_to_cmip7_atmosChem.yaml",
+        "aerosol": "noresm_to_cmip7_aerosol.yaml",
         "land": "noresm_to_cmip7_land.yaml",
         "seaIce": "noresm_to_cmip7_seaice.yaml",
     },
@@ -127,11 +129,23 @@ INCLUDE_PATTERN_MAP = {
             "6hr": ["cam.h2a"],
             "3hr": ["cam.h4a"],
         },
+        "atmosChem": {
+            "mon": ["cam.h0a"],
+            "day": ["cam.h1a"],
+            "6hr": ["cam.h2a"],
+            "3hr": ["cam.h4a"],
+        },
+        "aerosol": {
+            "mon": ["cam.h0a"],
+            "day": ["cam.h1a"],
+            "6hr": ["cam.h2a"],
+            "3hr": ["cam.h4a"],
+        },
         "land": {
             "mon": ["clm2.h0a"],
             "day": ["clm2.h1a"],
             "3hr": ["clm2.h2a"],
-            "yr": ["clm2.h3a"],
+            "yr":  ["clm2.h2a"] # Temporary change for WIEMIP TODO to change back ["clm2.h3a"],
         },
         "seaIce": {
             "mon": ["cice.h."],

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -78,6 +78,8 @@ MODEL_CONFIGS = {
         "realm_outputs": {
             "atmos": "noresm_to_cmip7_atmos.yaml",
             "land": "noresm_to_cmip7_land.yaml",
+            "aerosol": "noresm_to_cmip7_aerosol.yaml",
+            "atmosChem": "noresm_to_cmip7_atmosChem.yaml",
         },
         "source_column": "NorESM3 name (dependency)",
         "source_skip_phrases": [
@@ -129,6 +131,8 @@ MODEL_CONFIGS = {
         "realm_column": "Table",
         "realm_outputs": {
             "atmos": "cesm_to_cmip7_atmos.yaml",
+            "atmosChem": "cesm_to_cmip7_atmosChem.yaml",
+            "aerosol": "cesm_to_cmip7_aerosol.yaml",
             "land": "cesm_to_cmip7_land.yaml",
             "seaIce": "cesm_to_cmip7_seaice.yaml",
             "ocean": "cesm_to_cmip7_ocean.yaml",
@@ -528,6 +532,10 @@ def _build_entry(row, config):
                     dims = clean_strings(value.split(","), normalize)
             else:
                 dims = clean_strings(value.split(","), normalize)
+
+            if "pft" in dims:
+                pft_to_vegtype = True
+                dims = ["vegtype" if d == "pft" else d for d in dims]
             entry["dims"] = dims
             # Only search for plev in flat string lists; nested lists are left intact.
             plev_dim = next(

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -397,6 +397,8 @@ def sum_dim_detect(variable):
         return "fates_levlanduse"
     if variable.startswith("FATES") and variable.endswith("DC"):
         return "fates_levcwdsc"
+    if variable.startswith("FATES") and variable.endswith("EL"):
+        return "fates_levelem"
     if variable == "PCT_LANDUNIT":
         return "ltype"
     return "lev"

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -395,6 +395,8 @@ def sum_dim_detect(variable):
         return "fates_levpft"
     if variable.startswith("FATES") and variable.endswith("LU"):
         return "fates_levlanduse"
+    if variable.startswith("FATES") and variable.endswith("DC"):
+        return "fates_levcwdsc"
     if variable == "PCT_LANDUNIT":
         return "ltype"
     return "lev"

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -42,6 +42,7 @@ NORESM_POSITIVE_OVERRIDES: dict[str, str] = {
     "evspsblveg_tavg-u-hxy-u": "up",
     "ra_tavg-u-hxy-lnd": "up",
     "fN2O_tavg-u-hxy-lnd": "up",
+    "nbp_tavg-u-hxy-lnd": "down"
 }
 
 # ── model configurations ─────────────────────────────────────────────────────

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -401,6 +401,8 @@ def sum_dim_detect(variable):
         return "fates_levelem"
     if variable == "PCT_LANDUNIT":
         return "ltype"
+    if variable.startswith("FATES") and variable.endswith("SZ"):
+        return "fates_levscls"
     return "lev"
 
 

--- a/scripts/convert_csv_to_yaml.py
+++ b/scripts/convert_csv_to_yaml.py
@@ -40,6 +40,8 @@ NORESM_POSITIVE_OVERRIDES: dict[str, str] = {
     "tran_tavg-u-hxy-lnd": "up",
     "evspsblsoi_tavg-u-hxy-u": "up",
     "evspsblveg_tavg-u-hxy-u": "up",
+    "ra_tavg-u-hxy-lnd": "up",
+    "fN2O_tavg-u-hxy-lnd": "up",
 }
 
 # ── model configurations ─────────────────────────────────────────────────────
@@ -565,7 +567,7 @@ def _build_entry(row, config):
             entry["units"] = fix_number_norwegian_format(value)
         elif yaml_key == "_source_expr":
             names = _parse_csv_identifiers(value)
-            if names is not None:
+            if names is not None and "FATES" not in value:
                 # New format: comma-separated plain variable names.
                 # Freq/Alias will be merged in post-processing.
                 entry["sources"] = [{"model_var": n} for n in names]

--- a/src/cmip7_prep/cmor_writer.py
+++ b/src/cmip7_prep/cmor_writer.py
@@ -738,6 +738,20 @@ class CmorSession(
                 coord_vals=np.arange(len(values))#np.asarray(values),
             )
 
+        # -------------------------
+        # --- functional dimension: fates_levfuel
+        # -------------------------
+        elif "fates_levfuel" in var_dims:
+            values = ds["fates_levfuel"].values
+            logger.debug("Defining functional pft axis for variable %s", var_name)
+            logger.debug("fates_levfuel values: %s", values)
+            logger.debug("Setting functional pft axis")
+            funcax_id = cmor.axis(
+                table_entry="fuelclass",
+                units="",
+                coord_vals=np.arange(len(values))#np.asarray(values),
+            )
+
 
         # -------------------------
         # Map dimension names to axis IDs

--- a/src/cmip7_prep/cmor_writer.py
+++ b/src/cmip7_prep/cmor_writer.py
@@ -434,6 +434,7 @@ class CmorSession(
         lon_id = None
         sdepth_id = None
         lev_id = None
+        funcax_id = None
 
         logger.debug("[CMOR axis debug] var_dims: %s", var_dims)
         has_latlon_dims = "lat" in var_dims and "lon" in var_dims
@@ -723,6 +724,20 @@ class CmorSession(
                 coord_vals=np.asarray(values),
                 cell_bounds=bnds,
             )
+        # -------------------------
+        # --- functional dimension: fates_levpft
+        # -------------------------
+        elif "fates_levpft" in var_dims:
+            values = ds["fates_levpft"].values
+            logger.debug("Defining functional pft axis for variable %s", var_name)
+            logger.debug("fates_levpft values: %s", values)
+            logger.debug("Setting functional pft axis")
+            funcax_id = cmor.axis(
+                table_entry="pft",
+                units="",
+                coord_vals=np.arange(len(values))#np.asarray(values),
+            )
+
 
         # -------------------------
         # Map dimension names to axis IDs
@@ -743,6 +758,7 @@ class CmorSession(
             "yh": lat_id,  # MOM6
             "xq": lon_id,  # MOM6
             "yq": lat_id,  # MOM6
+            "fates_levpft": funcax_id,
         }
         axes_ids = []
         for d in var_dims:

--- a/src/cmip7_prep/cmor_writer.py
+++ b/src/cmip7_prep/cmor_writer.py
@@ -773,6 +773,7 @@ class CmorSession(
             "xq": lon_id,  # MOM6
             "yq": lat_id,  # MOM6
             "fates_levpft": funcax_id,
+            "fates_levfuel": funcax_id,
         }
         axes_ids = []
         for d in var_dims:

--- a/src/cmip7_prep/cmor_writer.py
+++ b/src/cmip7_prep/cmor_writer.py
@@ -108,10 +108,11 @@ class CmorSession(
         try:
             if self._log_path is not None:
                 logger.info("CMOR logfile: %s", self._log_path)
+                print()
                 cmor.setup(
                     inpath=str(self.tables_root / "tables"),
                     netcdf_file_action=getattr(
-                        cmor, "CMOR_REPLACE_3", getattr(cmor, "CMOR_REPLACE", 3)
+                        cmor, "CMOR_REPLACE_4", getattr(cmor, "CMOR_REPLACE", 4)
                     ),
                     set_verbosity=cmor.CMOR_NORMAL,
                     logfile=str(self._log_path),  # supported by newer CMOR builds
@@ -120,7 +121,7 @@ class CmorSession(
                 cmor.setup(
                     inpath=str(self.tables_root / "tables"),
                     netcdf_file_action=getattr(
-                        cmor, "CMOR_REPLACE_3", getattr(cmor, "CMOR_REPLACE", 3)
+                        cmor, "CMOR_REPLACE_4", getattr(cmor, "CMOR_REPLACE", 4)
                     ),
                     set_verbosity=cmor.CMOR_NORMAL,
                 )
@@ -129,7 +130,7 @@ class CmorSession(
             cmor.setup(
                 inpath=str(self.tables_root / "tables"),
                 netcdf_file_action=getattr(
-                    cmor, "CMOR_REPLACE_3", getattr(cmor, "CMOR_REPLACE", 3)
+                    cmor, "CMOR_REPLACE_4", getattr(cmor, "CMOR_REPLACE", 4)
                 ),
                 set_verbosity=cmor.CMOR_NORMAL,
             )

--- a/src/cmip7_prep/cmor_writer.py
+++ b/src/cmip7_prep/cmor_writer.py
@@ -220,6 +220,143 @@ class CmorSession(
         logger.debug("Loading CMOR table for key '%s': %s", key, table_filename)
         return cmor.load_table(table_filename)
 
+    def _define_mom6_grid(self, ds, var_name, var_da, var_dims):
+        """Register a MOM6 (xh/yh) curvilinear grid as 1D latitude/longitude axes.
+
+        Reads cell centers from the packaged ocean_geometry.nc, rolls longitude for
+        monotonicity, renames the native xh/yh (or xq/yq) dims to longitude/latitude,
+        and returns (i_id, j_id, var_da, var_dims) with the updated DataArray/dims.
+        """
+        logger.debug(
+            "[CMOR axis debug] Defining unstructured grid for variable %s.",
+            var_name,
+        )
+        geo_path = Path(__file__).parent.parent.parent / "data" / "ocean_geometry.nc"
+        if not geo_path.exists():
+            raise FileNotFoundError(f"Expected geometry file not found: {geo_path}")
+        ds_geo = xr.open_dataset(geo_path)
+        if "xh" in var_dims:
+            lon_raw = np.mod(ds_geo["lonh"].values, 360.0)
+        else:
+            lon_raw = np.mod(ds_geo["lonq"].values, 360.0)
+        lon_bnds_raw = bounds_from_centers_1d(lon_raw, "lon")
+        lon_vals_1d, lon_bnds, shift = roll_for_monotonic_with_bounds(
+            lon_raw, lon_bnds_raw
+        )
+        if "yh" in var_dims:
+            lat_vals_1d = ds_geo["lath"].values
+        elif "yq" in var_dims:
+            lat_vals_1d = ds_geo["latq"].values
+        else:
+            raise KeyError("Expected 'yh' or 'yq' dimension for latitude not found.")
+        # Fix first and last bounds to wrap correctly at the dateline
+        if lon_bnds.shape[0] > 1:
+            if lon_bnds[0, 0] > 0.0:
+                lon_bnds[0, 0] = 0.0
+                lon_bnds[-1, 1] = 360.0
+            lon_bnds[0, 1] = lon_bnds[1, 0]
+        i_id = cmor.axis(
+            table_entry="latitude",
+            units="degrees_north",
+            coord_vals=lat_vals_1d,
+            cell_bounds=bounds_from_centers_1d(lat_vals_1d, "lat"),
+        )
+        j_id = cmor.axis(
+            table_entry="longitude",
+            units="degrees_east",
+            coord_vals=lon_vals_1d,
+            cell_bounds=lon_bnds,
+        )
+        for dim in ("xh", "xq", "yh", "yq"):
+            if dim in var_dims:
+                logger.debug("[CMOR axis debug] renaming dim %s", dim)
+                if dim in ["xh", "xq"]:
+                    if dim == "xh":
+                        ds[str(var_name)] = var_da.roll(xh=-shift, roll_coords=True)
+                    elif dim == "xq":
+                        ds[str(var_name)] = var_da.roll(xq=-shift, roll_coords=True)
+                    ds[str(var_name)] = ds[str(var_name)].rename({dim: "longitude"})
+                if dim in ["yh", "yq"]:
+                    ds[str(var_name)] = ds[str(var_name)].rename({dim: "latitude"})
+
+        var_da = ds[str(var_name)]
+        var_dims = list(var_da.dims)
+        return i_id, j_id, var_da, var_dims
+
+    def _define_cice_grid(self, ds, var_name, var_da):
+        """Register a native CICE (nj, ni) tripole grid via cmor.grid().
+
+        The CICE grid is logically-rectangular: it carries TLAT/TLON cell centers
+        and vertex bounds (latt_bounds/lont_bounds, shape (nj, ni, nvertices))
+        inline. Defines i_index/j_index axes from the CMIP7 grids table and returns
+        the resulting grid id, which stands in for both the nj and ni dimensions.
+        """
+        logger.debug(
+            "[CMOR axis debug] Defining native CICE (nj, ni) grid for %s.",
+            var_name,
+        )
+        nj = var_da.sizes["nj"]
+        ni = var_da.sizes["ni"]
+
+        def _coord(dsi, *names):
+            for nm in names:
+                if nm in dsi.coords:
+                    return dsi.coords[nm]
+                if nm in dsi:
+                    return dsi[nm]
+            return None
+
+        tlat = _coord(ds, "TLAT", "tlat", "lat", "latitude")
+        tlon = _coord(ds, "TLON", "tlon", "lon", "longitude")
+        if tlat is None or tlon is None:
+            raise KeyError(
+                "CICE native grid requires TLAT/TLON cell-center coordinates "
+                f"in the dataset for variable '{var_name}'."
+            )
+
+        lat_bnds_da = None
+        lon_bnds_da = None
+        bname = tlat.attrs.get("bounds")
+        if isinstance(bname, str) and bname in ds:
+            lat_bnds_da = ds[bname]
+        bname = tlon.attrs.get("bounds")
+        if isinstance(bname, str) and bname in ds:
+            lon_bnds_da = ds[bname]
+        if lat_bnds_da is None:
+            lat_bnds_da = _coord(ds, "latt_bounds", "lat_bounds", "TLAT_bnds")
+        if lon_bnds_da is None:
+            lon_bnds_da = _coord(ds, "lont_bounds", "lon_bounds", "TLON_bnds")
+        if lat_bnds_da is None or lon_bnds_da is None:
+            raise KeyError(
+                "CICE native grid requires latitude/longitude vertex bounds "
+                f"(e.g. latt_bounds/lont_bounds) for variable '{var_name}'."
+            )
+
+        lat_vals = np.asarray(tlat.values, dtype="f8")
+        lon_vals = np.mod(np.asarray(tlon.values, dtype="f8"), 360.0)
+        lat_vert = np.asarray(lat_bnds_da.values, dtype="f8")
+        lon_vert = np.mod(np.asarray(lon_bnds_da.values, dtype="f8"), 360.0)
+
+        # Define the index axes and the grid against the CMIP7 grids table.
+        self.load_table(self.tables_root, "grids")
+        j_id = cmor.axis(
+            table_entry="j_index",
+            units="1",
+            coord_vals=np.arange(nj, dtype="i4"),
+        )
+        i_id = cmor.axis(
+            table_entry="i_index",
+            units="1",
+            coord_vals=np.arange(ni, dtype="i4"),
+        )
+        return cmor.grid(
+            axis_ids=[j_id, i_id],
+            latitude=lat_vals,
+            longitude=lon_vals,
+            latitude_vertices=lat_vert,
+            longitude_vertices=lon_vert,
+        )
+
     def _define_axes(self, ds: xr.Dataset, vdef: any) -> list[int]:
         """Define CMOR axis IDs for the variable in ds according to the CMOR tables.
 
@@ -309,80 +446,16 @@ class CmorSession(
             )
         i_id = None
         j_id = None
+        grid_id = None
         if ("xh" in var_dims or "xq" in var_dims) and (
             "yh" in var_dims or "yq" in var_dims
         ):
-            # MOM6/curvilinear grid: register xh/yh as generic axes (i/j), not as lat/lon
-            # Define the native grid using the coordinate arrays
-            logger.debug(
-                "[CMOR axis debug] Defining unstructured grid for variable %s.",
-                var_name,
+            i_id, j_id, var_da, var_dims = self._define_mom6_grid(
+                ds, var_name, var_da, var_dims
             )
-            logger.debug("[CMOR axis debug] write geolon axes")
 
-            geo_path = (
-                Path(__file__).parent.parent.parent / "data" / "ocean_geometry.nc"
-            )
-            if not geo_path.exists():
-                raise FileNotFoundError(f"Expected geometry file not found: {geo_path}")
-            ds_geo = xr.open_dataset(geo_path)
-            if "xh" in var_dims:
-                lon_raw = np.mod(ds_geo["lonh"].values, 360.0)
-            else:
-                lon_raw = np.mod(ds_geo["lonq"].values, 360.0)
-            lon_bnds_raw = bounds_from_centers_1d(lon_raw, "lon")
-            lon_vals_1d, lon_bnds, shift = roll_for_monotonic_with_bounds(
-                lon_raw, lon_bnds_raw
-            )
-            if "yh" in var_dims:
-                lat_vals_1d = ds_geo["lath"].values
-            elif "yq" in var_dims:
-                lat_vals_1d = ds_geo["latq"].values
-            else:
-                raise KeyError(
-                    "Expected 'yh' or 'yq' dimension for latitude not found."
-                )
-            # Fix first and last bounds to wrap correctly
-            if lon_bnds.shape[0] > 1:
-                # Ensure bounds are strictly increasing and wrap at dateline
-                if lon_bnds[0, 0] > 0.0:
-                    # Set first lower bound to 0, last upper bound to 360
-                    lon_bnds[0, 0] = 0.0
-                    lon_bnds[-1, 1] = 360.0
-                # Also correct first upper bound to match the first cell
-                lon_bnds[0, 1] = lon_bnds[1, 0]
-            logger.debug("[CMOR axis debug] corrected lon_bnds")
-            # Print lon_bnds for a range (debug)
-            i_id = cmor.axis(
-                table_entry="latitude",
-                units="degrees_north",
-                coord_vals=lat_vals_1d,
-                cell_bounds=bounds_from_centers_1d(lat_vals_1d, "lat"),
-            )
-            logger.debug("[CMOR axis debug] write geolat axes")
-            j_id = cmor.axis(
-                table_entry="longitude",
-                units="degrees_east",
-                coord_vals=lon_vals_1d,
-                cell_bounds=lon_bnds,
-            )
-            axes_ids.extend([j_id, i_id])
-            for dim in ("xh", "xq", "yh", "yq"):
-                if dim in var_dims:
-                    # rename dims xh and yh to longitude and latitude
-                    logger.debug("[CMOR axis debug] renaming dim %s", dim)
-
-                    if dim in ["xh", "xq"]:
-                        if dim == "xh":
-                            ds[str(var_name)] = var_da.roll(xh=-shift, roll_coords=True)
-                        elif dim == "xq":
-                            ds[str(var_name)] = var_da.roll(xq=-shift, roll_coords=True)
-                        ds[str(var_name)] = ds[str(var_name)].rename({dim: "longitude"})
-                    if dim in ["yh", "yq"]:
-                        ds[str(var_name)] = ds[str(var_name)].rename({dim: "latitude"})
-
-            var_da = ds[str(var_name)]
-            var_dims = list(var_da.dims)
+        elif "nj" in var_dims and "ni" in var_dims:
+            grid_id = self._define_cice_grid(ds, var_name, var_da)
 
         # -------------------------
         # --- horizontal axes (use CMOR names) ----
@@ -672,6 +745,13 @@ class CmorSession(
         }
         axes_ids = []
         for d in var_dims:
+            # For the CICE native grid, the 2D cmor.grid() id stands in for both
+            # the nj and ni dimensions: map nj -> grid_id and skip ni.
+            if grid_id is not None and d == "nj":
+                axes_ids.append(grid_id)
+                continue
+            if grid_id is not None and d == "ni":
+                continue
             axis_id = dim_to_axis.get(d)
             logger.debug("[CMOR axis debug] dim '%s' → axis_id: %s", d, axis_id)
             if axis_id is None:

--- a/src/cmip7_prep/regrid.py
+++ b/src/cmip7_prep/regrid.py
@@ -37,7 +37,8 @@ DEFAULT_BILIN_MAP_NE30_noresm = Path(
     INPUTDATA_DIR_noresm / "map_ne30pg3_to_1x1_bilin.nc"
 )
 DEFAULT_CONS_MAP_NE16_noresm = Path(
-    INPUTDATA_DIR_noresm / "map_ne16pg3_to_2x2_aave_c260531.nc"
+    #INPUTDATA_DIR_noresm / "map_ne16pg3_to_2x2_aave_c260531.nc"
+    INPUTDATA_DIR_noresm / "map_ne16pg3_to_1.9x2.5_nomask_scripgrids_c250425.nc"
 )
 DEFAULT_BILIN_MAP_NE16_noresm = Path(
     INPUTDATA_DIR_noresm / "map_ne16pg3_to_2x2_blin_c260531.nc"


### PR DESCRIPTION
## New cmor 3.15 tooling and and noresm seaice with no regridding

### Summary

This PR adds the tooling/environment changes needed to run against CMOR 3.15.
**This will involve creating a new conda environment** - the instructions are in a new file INSTALL.md

In addition, it bundles several NorESM-focused additions to the CMIP7 prep pipeline:
- native-grid sea-ice output
- two new realms (atmosChem and aerosols)
- a batch of land/FATES mapping fixes

### Tooling & environment (CMOR 3.15)

- Added `cmip7-cmor-tables` as a **git submodule** (NorESM fork of
  WCRP-CMIP/cmip7-cmor-tables) so each checkout gets a consistent, pinned set of
  CMIP7 tables.
- Added `INSTALL.md` documenting how to build the required Python 3.12 + CMOR
  3.15 conda environment (CMOR 3.15 is needed for the CMIP7 controlled-vocabulary
  checks; it has no Python 3.13 build).
- `pyproject.toml` updates.

 ### Sea ice — native-grid output (no regridding) for NorESM

- NorESM `seaIce` variables are no longer regridded to lat/lon; they are written
  on the **native CICE tripole grid** (`nj`/`ni`).
- Added native-grid CMOR writing via `cmor.grid()`, reading `TLAT`/`TLON` cell
  centers and their vertex bounds (`latt_bounds`/`lont_bounds`), with `i_index`/
  `j_index` axes.
- Refactored the writer so the **MOM6** and **CICE** grid/axis construction are
  separate, self-contained functions (`_define_mom6_grid`, `_define_cice_grid`)
  instead of inline branches in `_define_axes`.
- CESM behavior is unchanged: CESM sea-ice is still regridded to lat/lon upstream
  in the driver, so it never reaches the native-grid branch.
- Removed the now-obsolete `data/noresm_to_cmip7_seaice.yaml` entries.

### New realms — atmosChem and aerosols (NorESM)

- New mapping files: `data/noresm_to_cmip7_atmosChem.yaml` and
  `data/noresm_to_cmip7_aerosol.yaml`.
- Driver/writer fixes required to run the atmosChem and aerosol realms.

### Land / FATES fixes (NorESM)

- Updated `data/noresm_to_cmip7_land.yaml`.
- FATES corrections: `FATES_FRACTION` multiplication, `positive` attribute for
  `ra` and `fN2O`, `fates_levfuel` funcax hook, `fates_levelem` fix, straight
  `fates_levpft`→pft mapping and `_DC` dimension recognition for sum-over-pft,
  fuelclass mapping (WIEMIP).
- Added direction handling for `nbp`.



### Known limitation
- The conservative **2×2** regridding map is backed out for now: it triggers an
  index-out-of-bounds in `cache_tools._make_dummy_grids` (the output-grid path
  doesn't handle a 1-D destination grid the way the input path does). This needs
  a follow-up fix before 2×2 conservative regridding can be re-enabled.

## Test plan

- [ ] Build the env per `INSTALL.md` (Python 3.12, CMOR 3.15) and confirm
      `conda list cmor` shows `3.15.x`.
- [x] Run an atmos variable end-to-end (regridded path) and confirm CMOR output
      passes the CMIP7 CV checks (license_id, grid_label).
- [x] Run a NorESM `seaIce` variable and confirm it is written on the native
      tripole grid (`cmor.grid`, `grid_label`/grid attributes correct, no
      regridding).
- [ ] Run an atmosChem and an aerosol variable.
- [ ] Spot-check the land/FATES variables affected by the mapping fixes.
- [x] Confirm `git submodule update --init` populates `cmip7-cmor-tables` cleanly
      on a fresh checkout.
